### PR TITLE
Obsolete `version` attribute removed from `docker-compose.test.yml`

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     build:


### PR DESCRIPTION
in order to get rid of the `WARN[0000] [...]: the attribute 'version' is obsolete, it will be ignored, please remove it to avoid potential confusion` warning