### PR TITLE
`depends_on` service dependencies added to Docker Compose config files

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,9 @@ services:
     build:
       context: .
       dockerfile: app/docker/Dockerfile
+    depends_on:
+      - db-test
+      - redis-test
     environment:
       APP_DOMAIN: "app"
       DB_URL: postgresql+psycopg2://postgres:postgres@db-test:5432/mailgoose
@@ -17,6 +20,10 @@ services:
     build:
       context: .
       dockerfile: app/docker/Dockerfile
+    depends_on:
+      - bind9
+      - db-test
+      - redis-test
     environment:
       APP_DOMAIN: "app"
       DB_URL: postgresql+psycopg2://postgres:postgres@db-test:5432/mailgoose
@@ -41,6 +48,8 @@ services:
     build:
       context: .
       dockerfile: test/Dockerfile
+    depends_on:
+      - app
     command: bash -c "/wait-for-it.sh app:8000 -- python -m unittest discover"
   mailserver:
     image: ghcr.io/docker-mailserver/docker-mailserver:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     build:
       context: .
       dockerfile: app/docker/Dockerfile
+    depends_on:
+      - db
+      - redis
     environment:
       DB_URL: postgresql+psycopg2://postgres:postgres@db:5432/mailgoose
       FORWARDED_ALLOW_IPS: "*"
@@ -22,6 +25,10 @@ services:
     build:
       context: .
       dockerfile: app/docker/Dockerfile
+    depends_on:
+      - bind9
+      - db
+      - redis
     environment:
       DB_URL: postgresql+psycopg2://postgres:postgres@db:5432/mailgoose
       REDIS_URL: redis://redis:6379/0
@@ -34,6 +41,10 @@ services:
     build:
       context: .
       dockerfile: app/docker/Dockerfile
+    depends_on:
+      - bind9
+      - db
+      - redis
     environment:
       DB_URL: postgresql+psycopg2://postgres:postgres@db:5432/mailgoose
       REDIS_URL: redis://redis:6379/0
@@ -47,6 +58,8 @@ services:
       context: .
       dockerfile: mail_receiver/Dockerfile
     command: python3 /opt/server.py
+    depends_on:
+      - redis
     environment:
       REDIS_URL: redis://redis:6379/0
     env_file:


### PR DESCRIPTION
It's not only about service startup order (which seems to be guarded fine by the `wait-for-it.sh` scripts itself), but also about the order in which these services are taken down on shutdown.

Without this change, on shutdown, workers raise exceptions about Redis going down and try to reconnect to it (but it's already down, so it only causes more errors):

```
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 802, in <lambda>
worker2-1        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker2-1        |   File "/usr/local/lib/python3.11/site-packages/redis/connection.py", line 478, in can_read
worker2-1        |     return self._parser.can_read(timeout)
worker2-1        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker1-1        |     lambda error: self._disconnect_raise_connect(conn, error),
worker1-1        |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 789, in _disconnect_raise_connect
worker1-1        |     raise error
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/retry.py", line 46, in call_with_retry
worker1-1        |     return do()
worker2-1        |   File "/usr/local/lib/python3.11/site-packages/redis/_parsers/base.py", line 128, in can_read
worker1-1        |            ^^^^
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 801, in <lambda>
worker1-1        |     lambda: command(*args, **kwargs),
worker2-1        |     return self._buffer and self._buffer.can_read(timeout)
worker1-1        |             ^^^^^^^^^^^^^^^^^^^^^^^^
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/client.py", line 818, in try_read
worker1-1        |     if not conn.can_read(timeout=timeout):
worker1-1        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/connection.py", line 478, in can_read
worker1-1        |     return self._parser.can_read(timeout)
worker1-1        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker2-1        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker2-1        |   File "/usr/local/lib/python3.11/site-packages/redis/_parsers/socket.py", line 95, in can_read
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/_parsers/base.py", line 128, in can_read
worker1-1        |     return self._buffer and self._buffer.can_read(timeout)
worker1-1        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
worker2-1        |     return bool(self.unread_bytes()) or self._read_from_socket(
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/_parsers/socket.py", line 95, in can_read
worker1-1        |     return bool(self.unread_bytes()) or self._read_from_socket(
worker2-1        |                                         ^^^^^^^^^^^^^^^^^^^^^^^
worker1-1        |                                         ^^^^^^^^^^^^^^^^^^^^^^^
worker2-1        |   File "/usr/local/lib/python3.11/site-packages/redis/_parsers/socket.py", line 68, in _read_from_socket
worker1-1        |   File "/usr/local/lib/python3.11/site-packages/redis/_parsers/socket.py", line 68, in _read_from_socket
worker1-1        |     raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
worker1-1        | redis.exceptions.ConnectionError: Connection closed by server.
worker1-1        | ERROR:root:Error 111 connecting to redis:6379. Connection refused.
worker2-1        |     raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
worker2-1        | redis.exceptions.ConnectionError: Connection closed by server.
worker2-1        | ERROR:root:Error 111 connecting to redis:6379. Connection refused.
```