### PR TITLE
`#!/bin/bash` shebangs replaced with `#!/usr/bin/env bash`

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose -f docker-compose.test.yml down --remove-orphans
 docker compose -f docker-compose.test.yml up -d --build

--- a/scripts/update_translation_files
+++ b/scripts/update_translation_files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
Increases compatibility, for example the former does not work on NixOS.