### PR TITLE
DKIM: Display the full DKIM dns record and the selector used to find it

### DIFF
--- a/app/src/check_results.py
+++ b/app/src/check_results.py
@@ -71,6 +71,10 @@ def load_check_results(token: str) -> Optional[Dict[str, Any]]:
             result["result"]["message_timestamp"] = datetime.datetime.fromisoformat(
                 result["result"]["message_timestamp"]
             )
+        if "dkim" in result["result"] and "selector" not in result["result"]["dkim"]:
+            result["result"]["dkim"]["selector"] = ""
+        if "dkim" in result["result"] and "record" not in result["result"]["dkim"]:
+            result["result"]["dkim"]["record"] = ""
         if not result["result"]["domain"].get("domain_does_not_exist"):
             result["result"]["domain"]["domain_does_not_exist"] = False
         if not result["result"]["domain"].get("ssl"):

--- a/app/templates/check_results.html
+++ b/app/templates/check_results.html
@@ -327,6 +327,18 @@
                                                 <td><code>{{ dkim_domain }}</code></td>
                                             </tr>
                                         {% endif %}
+                                        {% if result.dkim.selector %}
+                                            <tr>
+                                                <td class="label">{% trans %}Selector{% endtrans %}</td>
+                                                <td><code>{{ result.dkim.selector }}</code></td>
+                                            </tr>
+                                        {% endif %}
+                                        {% if result.dkim.record %}
+                                            <tr>
+                                                <td class="label">{% trans %}Record{% endtrans %}</td>
+                                                <td><code>{{ result.dkim.record }}</code></td>
+                                            </tr>
+                                        {% endif %}
                                         <tr>
                                             <td class="label">{% trans %}Warnings{% endtrans %}</td>
                                             <td>{% if result.dkim.warnings %}{{ render_problems(result.dkim.warnings) }}{% else %}{% trans %}none{% endtrans %}{% endif %}</td>

--- a/app/translations/en_US/LC_MESSAGES/messages.po
+++ b/app/translations/en_US/LC_MESSAGES/messages.po
@@ -213,6 +213,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
+#: app/templates/check_results.html:338
 msgid "Record"
 msgstr ""
 
@@ -221,19 +222,19 @@ msgid "Records"
 msgstr ""
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:331
+#: app/templates/check_results.html:343
 msgid "Warnings"
 msgstr ""
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:332
-#: app/templates/check_results.html:336
+#: app/templates/check_results.html:272 app/templates/check_results.html:344
+#: app/templates/check_results.html:348
 msgid "none"
 msgstr ""
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:335
+#: app/templates/check_results.html:347
 msgid "Errors"
 msgstr ""
 
@@ -261,13 +262,17 @@ msgstr ""
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:348
+#: app/templates/check_results.html:332
+msgid "Selector"
+msgstr ""
+
+#: app/templates/check_results.html:360
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:356
+#: app/templates/check_results.html:368
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/lt_LT/LC_MESSAGES/messages.po
+++ b/app/translations/lt_LT/LC_MESSAGES/messages.po
@@ -232,6 +232,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
+#: app/templates/check_results.html:338
 msgid "Record"
 msgstr "Įrašas"
 
@@ -240,19 +241,19 @@ msgid "Records"
 msgstr "Įrašai"
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:331
+#: app/templates/check_results.html:343
 msgid "Warnings"
 msgstr "Įspėjimai"
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:332
-#: app/templates/check_results.html:336
+#: app/templates/check_results.html:272 app/templates/check_results.html:344
+#: app/templates/check_results.html:348
 msgid "none"
 msgstr "nėra"
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:335
+#: app/templates/check_results.html:347
 msgid "Errors"
 msgstr "Klaidos"
 
@@ -280,7 +281,11 @@ msgstr ""
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:348
+#: app/templates/check_results.html:332
+msgid "Selector"
+msgstr ""
+
+#: app/templates/check_results.html:360
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -289,7 +294,7 @@ msgstr ""
 "interpretuojama visų el. pašto serverių, mes rekomenduojame ištaisyti "
 "visas klaidas ir perspėjimus. "
 
-#: app/templates/check_results.html:356
+#: app/templates/check_results.html:368
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -213,6 +213,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
+#: app/templates/check_results.html:338
 msgid "Record"
 msgstr ""
 
@@ -221,19 +222,19 @@ msgid "Records"
 msgstr ""
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:331
+#: app/templates/check_results.html:343
 msgid "Warnings"
 msgstr ""
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:332
-#: app/templates/check_results.html:336
+#: app/templates/check_results.html:272 app/templates/check_results.html:344
+#: app/templates/check_results.html:348
 msgid "none"
 msgstr ""
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:335
+#: app/templates/check_results.html:347
 msgid "Errors"
 msgstr ""
 
@@ -261,13 +262,17 @@ msgstr ""
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:348
+#: app/templates/check_results.html:332
+msgid "Selector"
+msgstr ""
+
+#: app/templates/check_results.html:360
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:356
+#: app/templates/check_results.html:368
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/app/translations/pl_PL/LC_MESSAGES/messages.po
@@ -235,6 +235,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
+#: app/templates/check_results.html:338
 msgid "Record"
 msgstr "Rekord"
 
@@ -243,19 +244,19 @@ msgid "Records"
 msgstr "Rekordy"
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:331
+#: app/templates/check_results.html:343
 msgid "Warnings"
 msgstr "Ostrzeżenia"
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:332
-#: app/templates/check_results.html:336
+#: app/templates/check_results.html:272 app/templates/check_results.html:344
+#: app/templates/check_results.html:348
 msgid "none"
 msgstr "brak"
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:335
+#: app/templates/check_results.html:347
 msgid "Errors"
 msgstr "Błędy"
 
@@ -283,7 +284,11 @@ msgstr "Wynik"
 msgid "Configuration valid"
 msgstr "Konfiguracja prawidłowa"
 
-#: app/templates/check_results.html:348
+#: app/templates/check_results.html:332
+msgid "Selector"
+msgstr "Selektor"
+
+#: app/templates/check_results.html:360
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -292,7 +297,7 @@ msgstr ""
 "zinterpretowana przez wszystkie serwery, rekomendujemy poprawę zarówno "
 "błędów, jak i ostrzeżeń."
 
-#: app/templates/check_results.html:356
+#: app/templates/check_results.html:368
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/scan/libmailgoose/scan.py
+++ b/scan/libmailgoose/scan.py
@@ -93,6 +93,8 @@ class DomainScanResult:
 
 @dataclass
 class DKIMScanResult:
+    selector: Optional[str]
+    record: Optional[str]
     valid: bool
     errors: List[str]
     warnings: List[str]
@@ -210,6 +212,13 @@ def contains_spf_all_fail(parsed: Dict[str, Any]) -> bool:
     if "redirect" in parsed and parsed["redirect"]:
         return contains_spf_all_fail(parsed["redirect"]["parsed"])
     return False
+
+
+def _safe_decode_bytes(b: Optional[bytes]) -> Optional[str]:
+    if b is not None:
+        return b.decode("ascii", errors="replace")
+    else:
+        return None
 
 
 def scan_domain(
@@ -594,12 +603,17 @@ def scan_dkim(
 ) -> DKIMScanResult:
     if "dkim-signature" not in message_parsed:
         return DKIMScanResult(
+            selector=None,
+            record=None,
             valid=False,
             errors=["No DKIM signature found"],
             warnings=[],
         )
 
     opendkim_valid = subprocess.run(["opendkim-testmsg"], input=message).returncode == 0
+
+    selector_full_name = None
+    dkim_record_raw = None
 
     try:
         # We don't call dkim.verify() directly because it would catch dkim.DKIMException
@@ -617,17 +631,17 @@ def scan_dkim(
         else:
             warnings = []
 
-        selector_full_name = signature_tags[b"s"] + b"._domainkey." + signature_tags[b"d"] + b"."
-        if dkim_record_raw := dkim.dnsplug.get_txt(selector_full_name):
+        selector_full_name = signature_tags[b"s"] + b"._domainkey." + signature_tags[b"d"]
+        if dkim_record_raw := dkim.dnsplug.get_txt(selector_full_name + b"."):
             try:
                 dkim_record_tags = dkim.util.parse_tag_value(dkim_record_raw)
             except dkim.util.InvalidTagSpec as e:
                 raise dkim.DKIMException(
-                    "The DKIM DNS record contains an invalid tag: " + e.args[0].decode("ascii", errors="replace")
+                    f"The DKIM DNS record contains an invalid tag: {_safe_decode_bytes(e.args[0])}"
                 )
             except dkim.util.DuplicateTag as e:
                 raise dkim.DKIMException(
-                    "The DKIM DNS record contains an duplicate tag: " + e.args[0].decode("ascii", errors="replace")
+                    f"The DKIM DNS record contains an duplicate tag: {_safe_decode_bytes(e.args[0])}"
                 )
             if acceptable_hash_algorithms_raw := dkim_record_tags.get(b"h"):
                 acceptable_hash_algorithms: List[bytes] = acceptable_hash_algorithms_raw.split(b",")
@@ -650,12 +664,16 @@ def scan_dkim(
 
         if dkimpy_valid:
             return DKIMScanResult(
+                selector=_safe_decode_bytes(selector_full_name),
+                record=_safe_decode_bytes(dkim_record_raw),
                 valid=True,
                 errors=[],
                 warnings=warnings,
             )
         else:
             return DKIMScanResult(
+                selector=_safe_decode_bytes(selector_full_name),
+                record=_safe_decode_bytes(dkim_record_raw),
                 valid=False,
                 errors=["Found an invalid DKIM signature"],
                 warnings=warnings,
@@ -670,6 +688,8 @@ def scan_dkim(
 
         if e.args[0]:
             return DKIMScanResult(
+                selector=_safe_decode_bytes(selector_full_name),
+                record=_safe_decode_bytes(dkim_record_raw),
                 valid=False,
                 errors=[e.args[0]],
                 warnings=[],
@@ -678,6 +698,8 @@ def scan_dkim(
             LOGGER.exception("Error during DKIM signature validation")
 
             return DKIMScanResult(
+                selector=_safe_decode_bytes(selector_full_name),
+                record=_safe_decode_bytes(dkim_record_raw),
                 valid=False,
                 errors=["An unknown error occured during DKIM signature validation."],
                 warnings=[],


### PR DESCRIPTION
In English:
<img width="1466" height="269" alt="a_eng" src="https://github.com/user-attachments/assets/8c314886-1e96-400b-8e13-9a7d999c678c" />

In Polish:
<img width="1487" height="269" alt="a_pol" src="https://github.com/user-attachments/assets/3d1bbff8-7635-429c-bf54-a682394cd380" />

---

I have also tested what happens when a scan happened using an old version (without this feature in place yet) but we view the check results using this vesion. In this case no selector/record is displayed:

<img width="1461" height="266" alt="a_before" src="https://github.com/user-attachments/assets/59d0a557-4fb4-4d01-881d-09b7ef4cf169" />
