### PR TITLE
Enabled logging for the bind9 (`named`) container

### DIFF
--- a/docker-bind9/Dockerfile
+++ b/docker-bind9/Dockerfile
@@ -3,3 +3,5 @@ FROM internetsystemsconsortium/bind9:9.18
 ENV TZ=UTC
 
 COPY docker-bind9/named.conf /etc/bind/named.conf
+
+CMD ["-g", "-c", "/etc/bind/named.conf"]


### PR DESCRIPTION
The `internetsystemsconsortium/bind9:9.18` image is meant to be run with `/var/log` mounted for logs (source:
https://hub.docker.com/r/internetsystemsconsortium/bind9).

But we aren't doing it, and I guess we don't want to do it as it would be different to how all other containers handle logging.

Just that it means the container doesn't 

Instead of that I am proposing to override `CMD` (https://gitlab.isc.org/isc-projects/bind9-docker/-/blob/v9.18/Dockerfile) by adding the `-g` flag (it implies `-f`, also `-L` isn't needed anymore as we won't be storing any logs to disk) so that we inspect lofs using `docker compose logs`, the same way as for other containers.

Exceprt from the `named` man page:
```
     -f     This option runs the server in the foreground (i.e., do not daemonize).

     -g     This option runs the server in the foreground and forces all logging to stderr.

     -L logfile
            This option sets the log to the file logfile by default, instead of the system log.
```