### PR TITLE
DKIM: Displaying a warning when test mode is enabled (`t=y`)

### DIFF
--- a/scan/libmailgoose/scan.py
+++ b/scan/libmailgoose/scan.py
@@ -654,6 +654,11 @@ def scan_dkim(
                             "algorithm: " + acceptable_hash_algorithm.decode()
                         )
 
+            if dkim_flags_raw := dkim_record_tags.get(b"t"):
+                dkim_flags: List[bytes] = dkim_flags_raw.split(b":")
+                if b"y" in dkim_flags:
+                    warnings.append("Test mode is enabled for DKIM in the DNS record (t=y)")
+
         dkimpy_valid = d.verify()
 
         LOGGER.info(

--- a/scan/libmailgoose/translate.py
+++ b/scan/libmailgoose/translate.py
@@ -1190,6 +1190,10 @@ TRANSLATIONS = {
             f"Tag 'h' w rekordzie DNS, oznaczający akceptowane algorytmy haszujące, zawiera niewspierany algorytm: {PLACEHOLDER}",
         ),
         (
+            "Test mode is enabled for DKIM in the DNS record (t=y)",
+            "Włączony jest tryb testowy DKIM, sygnalizowany flagą 't=y' w rekordzie DNS",
+        ),
+        (
             f"The DKIM DNS record contains an invalid tag: {PLACEHOLDER}",
             f"Rekord DKIM w DNS zawiera nieprawidłowy tag: {PLACEHOLDER}",
         ),


### PR DESCRIPTION
It's a misconfiguration I have seen happening in the wild, it basically weakens how DKIM signatures are verified and does it in a non-obvious way.

From https://www.rfc-editor.org/info/rfc6376/#section-3.6.1:
```
   t= Flags, represented as a colon-separated list of names (plain-
      text; OPTIONAL, default is no flags set).  Unrecognized flags MUST
      be ignored.  The defined flags are as follows:

      y  This domain is testing DKIM.  Verifiers MUST NOT treat messages
         from Signers in testing mode differently from unsigned email,
         even should the signature fail to verify.  Verifiers MAY wish
         to track testing mode results to assist the Signer.
```

---

In English:
<img width="1462" height="407" alt="b_eng" src="https://github.com/user-attachments/assets/95771cbc-8217-428e-9d14-6bd967e5979f" />

In Polish:
<img width="1448" height="410" alt="b_pl" src="https://github.com/user-attachments/assets/7c6dd73a-cac9-4f0e-8798-b067d4ac2368" />
