### PR TITLE
Using a temporary directory to save the compiled `messages.mo` files

### DIFF
--- a/app/src/templates.py
+++ b/app/src/templates.py
@@ -1,5 +1,7 @@
 import gettext
+import os
 import subprocess
+import tempfile
 
 from fastapi.templating import Jinja2Templates
 
@@ -10,21 +12,25 @@ from .template_utils import mailgoose_urlize
 def setup_templates(language: str) -> Jinja2Templates:
     templates = Jinja2Templates(directory="templates", extensions=[BuildIDTag, LanguageTag, "jinja2.ext.i18n"])
     templates.env.filters["mailgoose_urlize"] = mailgoose_urlize
-    subprocess.call(
-        [
-            "pybabel",
-            "compile",
-            "-f",
-            "--input",
-            f"/app/translations/{language}/LC_MESSAGES/messages.po",
-            "--output",
-            f"/app/translations/{language}/LC_MESSAGES/messages.mo",
-        ],
-        stderr=subprocess.DEVNULL,  # suppress a misleading message where compiled translations will be saved
-    )
 
-    templates.env.install_gettext_translations(  # type: ignore
-        gettext.translation(domain="messages", localedir="/app/translations", languages=[language]), newstyle=True
-    )
+    with tempfile.TemporaryDirectory() as localedir:
+        output_dir = os.path.join(localedir, language, "LC_MESSAGES")
+        os.makedirs(output_dir)
+        subprocess.call(
+            [
+                "pybabel",
+                "compile",
+                "-f",
+                "--input",
+                f"/app/translations/{language}/LC_MESSAGES/messages.po",
+                "--output",
+                os.path.join(output_dir, "messages.mo"),
+            ],
+            stderr=subprocess.DEVNULL,  # suppress a misleading message where compiled translations will be saved
+        )
+
+        templates.env.install_gettext_translations(  # type: ignore
+            gettext.translation(domain="messages", localedir=localedir, languages=[language]), newstyle=True
+        )
 
     return templates


### PR DESCRIPTION
Fixes race conditon exception (https://github.com/CERT-Polska/mailgoose/issues/214) when multiple workers try to write and then read the same file.