### PR TITLE
Show whether received email has been delivered with TLS encryption

### DIFF
--- a/app/src/app.py
+++ b/app/src/app.py
@@ -206,6 +206,7 @@ async def check_domain_api(request: Request, domain: str) -> ScanAPICallResult:
             message=None,
             message_sender_ip=None,
             message_timestamp=None,
+            incoming_tls_status=None,
             nameservers=Config.Network.NAMESERVERS,
             language=Language(Config.UI.LANGUAGE),
             client_ip=client_ip,

--- a/app/src/app_utils.py
+++ b/app/src/app_utils.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Tuple
 import dkim.util
 from email_validator import EmailNotValidError, validate_email
 from libmailgoose.language import Language
-from libmailgoose.scan import ScanResult, scan
+from libmailgoose.scan import IncomingTLSStatus, ScanResult, scan
 from libmailgoose.translate import translate_scan_result
 
 from common.config import Config
@@ -76,6 +76,7 @@ def scan_and_log(
     message: Optional[bytes],
     message_sender_ip: Optional[bytes],
     message_timestamp: Optional[datetime.datetime],
+    incoming_tls_status: Optional[IncomingTLSStatus],
     nameservers: List[str],
     language: Language,
     client_ip: Optional[str],
@@ -98,6 +99,7 @@ def scan_and_log(
         dkim=None,
         timestamp=datetime.datetime.now(),
         message_timestamp=message_timestamp,
+        incoming_tls_status=incoming_tls_status,
     )
 
     try:
@@ -109,6 +111,7 @@ def scan_and_log(
                 message=message,
                 message_sender_ip=message_sender_ip,
                 message_timestamp=message_timestamp,
+                incoming_tls_status=incoming_tls_status,
                 nameservers=nameservers,
                 dkim_implementation_mismatch_callback=dkim_implementation_mismatch_callback,
             ),

--- a/app/src/check_results.py
+++ b/app/src/check_results.py
@@ -4,7 +4,7 @@ import json
 from typing import Any, Dict, Optional
 
 import dacite
-from libmailgoose.scan import ScanResult
+from libmailgoose.scan import IncomingTLSStatus, ScanResult
 from redis import Redis
 
 from common.config import Config
@@ -94,6 +94,7 @@ def load_check_results(token: str) -> Optional[Dict[str, Any]]:
             dacite.from_dict(
                 data_class=ScanResult,
                 data=result["result"],
+                config=dacite.Config(cast=[IncomingTLSStatus]),
             )
         except dacite.WrongTypeError:
             LOGGER.exception("Wrong type detected when deserializing")
@@ -103,7 +104,7 @@ def load_check_results(token: str) -> Optional[Dict[str, Any]]:
         result["result"] = dacite.from_dict(
             data_class=ScanResult,
             data=result["result"],
-            config=dacite.Config(check_types=False),
+            config=dacite.Config(check_types=False, cast=[IncomingTLSStatus]),
         )
 
     result["age_threshold_minutes"] = Config.UI.OLD_CHECK_RESULTS_AGE_MINUTES

--- a/app/src/worker.py
+++ b/app/src/worker.py
@@ -3,7 +3,11 @@ import traceback
 from typing import Optional
 
 from libmailgoose.language import Language
-from libmailgoose.scan import DomainValidationException, ScanningException
+from libmailgoose.scan import (
+    DomainValidationException,
+    IncomingTLSStatus,
+    ScanningException,
+)
 from libmailgoose.translate import translate
 from redis import Redis
 
@@ -21,6 +25,15 @@ REDIS = Redis.from_url(Config.Data.REDIS_URL)
 setup_resolver()
 
 
+def _decode_tls_flag(raw: Optional[bytes]) -> Optional[IncomingTLSStatus]:
+    if raw is None:
+        return None
+    try:
+        return IncomingTLSStatus(raw.decode("ascii"))
+    except (UnicodeDecodeError, ValueError):
+        return None
+
+
 def scan_domain_job(
     client_ip: Optional[str],
     client_user_agent: Optional[str],
@@ -36,6 +49,7 @@ def scan_domain_job(
             message=None,
             message_sender_ip=None,
             message_timestamp=None,
+            incoming_tls_status=None,
             nameservers=Config.Network.NAMESERVERS,
             language=Language(Config.UI.LANGUAGE),
             client_ip=client_ip,
@@ -78,11 +92,13 @@ def scan_message_and_domain_job(
     message_data = REDIS.get(message_key)
     message_sender_ip = REDIS.get(message_key + b"-sender_ip")
     message_timestamp_raw = REDIS.get(message_key + b"-timestamp")
+    message_tls_raw = REDIS.get(message_key + b"-tls")
 
     if not message_data or not message_sender_ip or not message_timestamp_raw:
         raise RuntimeError("Worker coudn't access message data")
 
     message_timestamp = datetime.datetime.fromisoformat(message_timestamp_raw.decode("ascii"))
+    incoming_tls_status = _decode_tls_flag(message_tls_raw)
 
     from_domain, dkim_domain = get_from_and_dkim_domain(message_data)
     if not from_domain:
@@ -98,6 +114,7 @@ def scan_message_and_domain_job(
                 message=message_data,
                 message_sender_ip=message_sender_ip,
                 message_timestamp=message_timestamp,
+                incoming_tls_status=incoming_tls_status,
                 nameservers=Config.Network.NAMESERVERS,
                 language=Language(Config.UI.LANGUAGE),
                 client_ip=client_ip,

--- a/app/templates/check_results.html
+++ b/app/templates/check_results.html
@@ -289,7 +289,7 @@
                             }) }}
                             <div class="card-body">
                                 <div class="card border rounded-3 mb-3">
-                                    {{ card_header(gettext("Outgoing mail"), result.domain.ssl) }}
+                                    {{ card_header(gettext("Incoming mail"), result.domain.ssl) }}
                                     <div class="card-body">
                                          <table class="table">
                                              <thead>
@@ -336,7 +336,7 @@
 
                                 {% if result.incoming_tls_status %}
                                     <div class="card border rounded-3 mb-0">
-                                        {{ card_header(gettext("Incoming mail"), {
+                                        {{ card_header(gettext("Outgoing mail"), {
                                             "valid": result.incoming_tls_status != 'not_used',
                                             "could_not_be_tested": result.incoming_tls_status == 'not_testable',
                                         }) }}

--- a/app/templates/check_results.html
+++ b/app/templates/check_results.html
@@ -27,7 +27,7 @@
     <div class="card-header
             {% if not data.valid %}
                 text-danger
-            {% elif data.record_could_not_be_fully_validated %}
+            {% elif data.record_could_not_be_fully_validated or data.could_not_be_tested %}
                 text-disabled
             {% elif data.warnings %}
                 text-warning-dark
@@ -37,7 +37,7 @@
 
         {% if not data.valid %}
             <i class="bi bi-x-square"></i>
-        {% elif data.record_could_not_be_fully_validated %}
+        {% elif data.record_could_not_be_fully_validated or data.could_not_be_tested %}
             <i class="bi bi-question-circle"></i>
         {% elif data.warnings %}
             <i class="bi bi-exclamation-triangle"></i>
@@ -49,6 +49,8 @@
             {% trans %}incorrect configuration{% endtrans %}
         {% elif data.record_could_not_be_fully_validated %}
             {% trans %}record couldn't be fully verified{% endtrans %}
+        {% elif data.could_not_be_tested %}
+            {% trans %}couldn't be tested{% endtrans %}
         {% elif data.warnings %}
             {% trans %}configuration warnings{% endtrans %}
         {% else %}
@@ -281,36 +283,62 @@
 
                     {% if result.domain.ssl %}
                         <div class="card p-1 bg-light border rounded-3 mb-3">
-                            {{ card_header("SSL/TLS", result.domain.ssl) }}
+                            {{ card_header("SSL/TLS", {
+                                "valid": result.domain.ssl.valid and result.incoming_tls_status != 'not_used',
+                                "warnings": result.domain.ssl.warnings,
+                            }) }}
                             <div class="card-body">
-                                <table class="table">
-                                    <thead>
-                                        <tr>
-                                            <th class="d-none d-sm-table-cell">{% trans %}Preference{% endtrans %}</th>
-                                            <th class="d-table-cell d-sm-none">&nbsp;</th>
-                                            <th class="d-none d-sm-table-cell">{% trans %}Server{% endtrans %}</th>
-                                            <th class="d-none d-sm-table-cell">{% trans %}Port{% endtrans %}</th>
-                                            <th>{% trans %}Result{% endtrans %}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for item in result.domain.ssl.results %}
-                                            <tr>
-                                                <td class="d-none d-sm-table-cell">{% if item.preference is not none %}{{ item.preference }}{% else %}-{% endif %}</td>
-                                                <td class="d-table-cell d-sm-none">{{ item.mx }}:{% if item.port %}{{ item.port }}{% else %}-{% endif %}</td>
-                                                <td class="d-none d-sm-table-cell">{{ item.mx }}</td>
-                                                <td class="d-none d-sm-table-cell">{% if item.port %}{{ item.port }}{% else %}-{% endif %}</td>
-                                                {% if item.error %}
-                                                    <td class="text-danger">{{ item.error }}</td>
-                                                {% elif item.warning %}
-                                                    <td class="text-warning-dark">{{ item.warning }}</td>
-                                                {% else %}
-                                                    <td class="text-success">{% trans %}Configuration valid{% endtrans %}</td>
-                                                {% endif %}
-                                            </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
+                                <div class="card border rounded-3 mb-3">
+                                    {{ card_header(gettext("Incoming mail"), result.domain.ssl) }}
+                                    <div class="card-body">
+                                        <table class="table mb-0">
+                                            <thead>
+                                                <tr>
+                                                    <th class="d-none d-sm-table-cell">{% trans %}Preference{% endtrans %}</th>
+                                                    <th class="d-table-cell d-sm-none">&nbsp;</th>
+                                                    <th class="d-none d-sm-table-cell">{% trans %}Server{% endtrans %}</th>
+                                                    <th class="d-none d-sm-table-cell">{% trans %}Port{% endtrans %}</th>
+                                                    <th>{% trans %}Result{% endtrans %}</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {% for item in result.domain.ssl.results %}
+                                                    <tr>
+                                                        <td class="d-none d-sm-table-cell">{% if item.preference is not none %}{{ item.preference }}{% else %}-{% endif %}</td>
+                                                        <td class="d-table-cell d-sm-none">{{ item.mx }}:{% if item.port %}{{ item.port }}{% else %}-{% endif %}</td>
+                                                        <td class="d-none d-sm-table-cell">{{ item.mx }}</td>
+                                                        <td class="d-none d-sm-table-cell">{% if item.port %}{{ item.port }}{% else %}-{% endif %}</td>
+                                                        {% if item.error %}
+                                                            <td class="text-danger">{{ item.error }}</td>
+                                                        {% elif item.warning %}
+                                                            <td class="text-warning-dark">{{ item.warning }}</td>
+                                                        {% else %}
+                                                            <td class="text-success">{% trans %}Configuration valid{% endtrans %}</td>
+                                                        {% endif %}
+                                                    </tr>
+                                                {% endfor %}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                {% if result.incoming_tls_status %}
+                                    <div class="card border rounded-3 mb-0">
+                                        {{ card_header(gettext("Outgoing mail"), {
+                                            "valid": result.incoming_tls_status != 'not_used',
+                                            "could_not_be_tested": result.incoming_tls_status == 'not_testable',
+                                        }) }}
+                                        <div class="card-body">
+                                            {% if result.incoming_tls_status == 'used' %}
+                                                {% trans %}Your mail server delivered the test message over TLS.{% endtrans %}
+                                            {% elif result.incoming_tls_status == 'not_used' %}
+                                                {% trans %}Your mail server delivered the test message without TLS.{% endtrans %}
+                                            {% elif result.incoming_tls_status == 'not_testable' %}
+                                                {% trans %}TLS support couldn't be tested - this instance is not configured with a TLS certificate, so the sender couldn't have used TLS even if they wanted to.{% endtrans %}
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                {% endif %}
                             </div>
                         </div>
                     {% endif %}

--- a/app/translations/en_US/LC_MESSAGES/messages.po
+++ b/app/translations/en_US/LC_MESSAGES/messages.po
@@ -19,10 +19,10 @@ msgstr ""
 msgid "Check domain"
 msgstr ""
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:354
 msgid "Domain"
 msgstr ""
 
@@ -92,109 +92,113 @@ msgid "record couldn't be fully verified"
 msgstr ""
 
 #: app/templates/check_results.html:53
-msgid "configuration warnings"
+msgid "couldn't be tested"
 msgstr ""
 
 #: app/templates/check_results.html:55
+msgid "configuration warnings"
+msgstr ""
+
+#: app/templates/check_results.html:57
 msgid "correct configuration"
 msgstr ""
 
-#: app/templates/check_results.html:81
+#: app/templates/check_results.html:83
 msgid "e-mail sender verification mechanisms check results:"
 msgstr ""
 
-#: app/templates/check_results.html:83
+#: app/templates/check_results.html:85
 msgid "E-mail sender verification mechanisms check results:"
 msgstr ""
 
-#: app/templates/check_results.html:86
+#: app/templates/check_results.html:88
 msgid "SPF and DMARC"
 msgstr ""
 
-#: app/templates/check_results.html:87
+#: app/templates/check_results.html:89
 msgid "DKIM"
 msgstr ""
 
-#: app/templates/check_results.html:88
+#: app/templates/check_results.html:90
 msgid "SPF, DMARC and DKIM"
 msgstr ""
 
-#: app/templates/check_results.html:95
+#: app/templates/check_results.html:97
 #, python-format
 msgid ""
 "The results you are viewing are older than %(age_threshold_minutes)s "
 "minutes."
 msgstr ""
 
-#: app/templates/check_results.html:100
+#: app/templates/check_results.html:102
 #, python-format
 msgid ""
 "If you want to view up-to-date results, please <a "
 "href='%(rescan_url)s'>run a new check.</a>"
 msgstr ""
 
-#: app/templates/check_results.html:109
+#: app/templates/check_results.html:111
 msgid "Test date: "
 msgstr ""
 
-#: app/templates/check_results.html:110
+#: app/templates/check_results.html:112
 #, python-format
 msgid "(e-mail message from %(date_str)s)"
 msgstr ""
 
-#: app/templates/check_results.html:113
+#: app/templates/check_results.html:115
 msgid "To share check results, copy the following link:"
 msgstr ""
 
-#: app/templates/check_results.html:124
+#: app/templates/check_results.html:126
 msgid "Domain does not exist."
 msgstr ""
 
-#: app/templates/check_results.html:137
+#: app/templates/check_results.html:139
 msgid "Check summary"
 msgstr ""
 
-#: app/templates/check_results.html:141
+#: app/templates/check_results.html:143
 msgctxt "zero"
 msgid "mechanisms"
-msgstr ""
-
-#: app/templates/check_results.html:143
-msgid "mechanism"
 msgstr ""
 
 #: app/templates/check_results.html:145
-msgid "mechanisms"
+msgid "mechanism"
 msgstr ""
 
 #: app/templates/check_results.html:147
+msgid "mechanisms"
+msgstr ""
+
+#: app/templates/check_results.html:149
 msgid "out of"
 msgstr ""
 
-#: app/templates/check_results.html:150
-msgctxt "zero"
-msgid "configured"
-msgstr ""
-
 #: app/templates/check_results.html:152
-msgctxt "singular"
+msgctxt "zero"
 msgid "configured"
 msgstr ""
 
 #: app/templates/check_results.html:154
-msgctxt "plural"
+msgctxt "singular"
 msgid "configured"
 msgstr ""
 
 #: app/templates/check_results.html:156
+msgctxt "plural"
+msgid "configured"
+msgstr ""
+
+#: app/templates/check_results.html:158
 msgid "without issues."
 msgstr ""
 
-#: app/templates/check_results.html:173
+#: app/templates/check_results.html:175
 msgid "SPF: the record is optional"
 msgstr ""
 
-#: app/templates/check_results.html:177
+#: app/templates/check_results.html:179
 msgid ""
 "Because the DMARC record is configured correctly, the SPF record is not "
 "required. Sending e-mail messages from this domain without using the SPF "
@@ -202,7 +206,7 @@ msgid ""
 "correct DKIM signatures."
 msgstr ""
 
-#: app/templates/check_results.html:184
+#: app/templates/check_results.html:186
 msgid ""
 "However, we recommend configuring an SPF record if possible (even if the "
 "domain is not used to send e-mails), because older mail servers may not "
@@ -211,68 +215,91 @@ msgid ""
 "properly verify e-mail message authenticity."
 msgstr ""
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:366
 msgid "Record"
 msgstr ""
 
-#: app/templates/check_results.html:210 app/templates/check_results.html:250
+#: app/templates/check_results.html:212 app/templates/check_results.html:252
 msgid "Records"
 msgstr ""
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:371
 msgid "Warnings"
 msgstr ""
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:372
+#: app/templates/check_results.html:376 app/templates/check_results.html:384
 msgid "none"
 msgstr ""
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:375
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:269 app/templates/check_results.html:379
 msgid "Additional information"
 msgstr ""
 
-#: app/templates/check_results.html:289
+#: app/templates/check_results.html:292
+msgid "Incoming mail"
+msgstr ""
+
+#: app/templates/check_results.html:297
 msgid "Preference"
 msgstr ""
 
-#: app/templates/check_results.html:291
+#: app/templates/check_results.html:299
 msgid "Server"
 msgstr ""
 
-#: app/templates/check_results.html:292
+#: app/templates/check_results.html:300
 msgid "Port"
 msgstr ""
 
-#: app/templates/check_results.html:293
+#: app/templates/check_results.html:301
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:327
+msgid "Outgoing mail"
+msgstr ""
+
+#: app/templates/check_results.html:333
+msgid "Your mail server delivered the test message over TLS."
+msgstr ""
+
+#: app/templates/check_results.html:335
+msgid "Your mail server delivered the test message without TLS."
+msgstr ""
+
+#: app/templates/check_results.html:337
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+
+#: app/templates/check_results.html:360
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:399
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:407
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/en_US/LC_MESSAGES/messages.po
+++ b/app/translations/en_US/LC_MESSAGES/messages.po
@@ -248,7 +248,7 @@ msgid "Additional information"
 msgstr ""
 
 #: app/templates/check_results.html:292
-msgid "Outgoing mail"
+msgid "Incoming mail"
 msgstr ""
 
 #: app/templates/check_results.html:297
@@ -272,7 +272,7 @@ msgid "Configuration valid"
 msgstr ""
 
 #: app/templates/check_results.html:339
-msgid "Incoming mail"
+msgid "Outgoing mail"
 msgstr ""
 
 #: app/templates/check_results.html:345

--- a/app/translations/en_US/LC_MESSAGES/messages.po
+++ b/app/translations/en_US/LC_MESSAGES/messages.po
@@ -19,10 +19,10 @@ msgstr ""
 msgid "Check domain"
 msgstr ""
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:338
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:366
 msgid "Domain"
 msgstr ""
 
@@ -215,9 +215,9 @@ msgid ""
 "properly verify e-mail message authenticity."
 msgstr ""
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:350
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:378
 msgid "Record"
 msgstr ""
 
@@ -225,30 +225,30 @@ msgstr ""
 msgid "Records"
 msgstr ""
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:313 app/templates/check_results.html:355
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:321 app/templates/check_results.html:383
 msgid "Warnings"
 msgstr ""
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:356
-#: app/templates/check_results.html:360 app/templates/check_results.html:368
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:384
+#: app/templates/check_results.html:388 app/templates/check_results.html:396
 msgid "none"
 msgstr ""
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:309 app/templates/check_results.html:359
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:317 app/templates/check_results.html:387
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:317
-#: app/templates/check_results.html:363
+#: app/templates/check_results.html:269 app/templates/check_results.html:325
+#: app/templates/check_results.html:391
 msgid "Additional information"
 msgstr ""
 
 #: app/templates/check_results.html:292
-msgid "Incoming mail"
+msgid "Outgoing mail"
 msgstr ""
 
 #: app/templates/check_results.html:297
@@ -267,21 +267,40 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:306
+#: app/templates/check_results.html:314
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:344
+#: app/templates/check_results.html:339
+msgid "Incoming mail"
+msgstr ""
+
+#: app/templates/check_results.html:345
+msgid "Your mail server delivered the test message over TLS."
+msgstr ""
+
+#: app/templates/check_results.html:347
+msgid "Your mail server delivered the test message without TLS."
+msgstr ""
+
+#: app/templates/check_results.html:349
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+
+#: app/templates/check_results.html:372
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:383
+#: app/templates/check_results.html:411
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:391
+#: app/templates/check_results.html:419
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/lt_LT/LC_MESSAGES/messages.po
+++ b/app/translations/lt_LT/LC_MESSAGES/messages.po
@@ -19,10 +19,10 @@ msgstr "Nukopijuota"
 msgid "Check domain"
 msgstr "Tikrinti domeną"
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:338
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:366
 msgid "Domain"
 msgstr "Domenas"
 
@@ -234,9 +234,9 @@ msgstr ""
 " mechanizmų SPF, DKIM ir DMARC - kombinacija leidžia visiems serveriams "
 "tinkamai patikrinti el. pašto žinučių autentiškumą."
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:350
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:378
 msgid "Record"
 msgstr "Įrašas"
 
@@ -244,30 +244,30 @@ msgstr "Įrašas"
 msgid "Records"
 msgstr "Įrašai"
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:313 app/templates/check_results.html:355
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:321 app/templates/check_results.html:383
 msgid "Warnings"
 msgstr "Įspėjimai"
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:356
-#: app/templates/check_results.html:360 app/templates/check_results.html:368
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:384
+#: app/templates/check_results.html:388 app/templates/check_results.html:396
 msgid "none"
 msgstr "nėra"
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:309 app/templates/check_results.html:359
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:317 app/templates/check_results.html:387
 msgid "Errors"
 msgstr "Klaidos"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:317
-#: app/templates/check_results.html:363
+#: app/templates/check_results.html:269 app/templates/check_results.html:325
+#: app/templates/check_results.html:391
 msgid "Additional information"
 msgstr ""
 
 #: app/templates/check_results.html:292
-msgid "Incoming mail"
+msgid "Outgoing mail"
 msgstr ""
 
 #: app/templates/check_results.html:297
@@ -286,15 +286,34 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:306
+#: app/templates/check_results.html:314
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:344
+#: app/templates/check_results.html:339
+msgid "Incoming mail"
+msgstr ""
+
+#: app/templates/check_results.html:345
+msgid "Your mail server delivered the test message over TLS."
+msgstr ""
+
+#: app/templates/check_results.html:347
+msgid "Your mail server delivered the test message without TLS."
+msgstr ""
+
+#: app/templates/check_results.html:349
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+
+#: app/templates/check_results.html:372
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:383
+#: app/templates/check_results.html:411
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -303,7 +322,7 @@ msgstr ""
 "interpretuojama visų el. pašto serverių, mes rekomenduojame ištaisyti "
 "visas klaidas ir perspėjimus. "
 
-#: app/templates/check_results.html:391
+#: app/templates/check_results.html:419
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/lt_LT/LC_MESSAGES/messages.po
+++ b/app/translations/lt_LT/LC_MESSAGES/messages.po
@@ -19,10 +19,10 @@ msgstr "Nukopijuota"
 msgid "Check domain"
 msgstr "Tikrinti domeną"
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:354
 msgid "Domain"
 msgstr "Domenas"
 
@@ -100,41 +100,45 @@ msgid "record couldn't be fully verified"
 msgstr "įrašas negali būti pilnai patvirtintas"
 
 #: app/templates/check_results.html:53
+msgid "couldn't be tested"
+msgstr ""
+
+#: app/templates/check_results.html:55
 msgid "configuration warnings"
 msgstr "konfiguracijos klaidos"
 
-#: app/templates/check_results.html:55
+#: app/templates/check_results.html:57
 msgid "correct configuration"
 msgstr "teisinga konfiguracija"
 
-#: app/templates/check_results.html:81
+#: app/templates/check_results.html:83
 msgid "e-mail sender verification mechanisms check results:"
 msgstr "pašto saugos testo rezultatai"
 
-#: app/templates/check_results.html:83
+#: app/templates/check_results.html:85
 msgid "E-mail sender verification mechanisms check results:"
 msgstr "pašto saugos testo rezultatai"
 
-#: app/templates/check_results.html:86
+#: app/templates/check_results.html:88
 msgid "SPF and DMARC"
 msgstr "SPF ir DMARC"
 
-#: app/templates/check_results.html:87
+#: app/templates/check_results.html:89
 msgid "DKIM"
 msgstr "DKIM"
 
-#: app/templates/check_results.html:88
+#: app/templates/check_results.html:90
 msgid "SPF, DMARC and DKIM"
 msgstr "SPF, DMARC ir DKIM"
 
-#: app/templates/check_results.html:95
+#: app/templates/check_results.html:97
 #, python-format
 msgid ""
 "The results you are viewing are older than %(age_threshold_minutes)s "
 "minutes."
 msgstr "Rezultatai kuriuos žiūrite yra senesni nei %(age_threshold_minutes)s min."
 
-#: app/templates/check_results.html:100
+#: app/templates/check_results.html:102
 #, python-format
 msgid ""
 "If you want to view up-to-date results, please <a "
@@ -143,69 +147,69 @@ msgstr ""
 "Jeigu norite pamatyti naujausius rezultatus, prašome <a "
 "href='%(rescan_url)s'>atlikti naują patikrinimą.</a>"
 
-#: app/templates/check_results.html:109
+#: app/templates/check_results.html:111
 msgid "Test date: "
 msgstr "Testo data: "
 
-#: app/templates/check_results.html:110
+#: app/templates/check_results.html:112
 #, python-format
 msgid "(e-mail message from %(date_str)s)"
 msgstr "(el-laiškas žinutė iš %(date_str)s)"
 
-#: app/templates/check_results.html:113
+#: app/templates/check_results.html:115
 msgid "To share check results, copy the following link:"
 msgstr "Jei norite pasidalinti patikrinimo rezultatais, nukopijuokite šią nuorodą:"
 
-#: app/templates/check_results.html:124
+#: app/templates/check_results.html:126
 msgid "Domain does not exist."
 msgstr ""
 
 # "link:"
-#: app/templates/check_results.html:137
+#: app/templates/check_results.html:139
 msgid "Check summary"
 msgstr "Patikrinimo rezultatai"
 
-#: app/templates/check_results.html:141
+#: app/templates/check_results.html:143
 msgctxt "zero"
 msgid "mechanisms"
 msgstr "mechanizmai"
 
-#: app/templates/check_results.html:143
+#: app/templates/check_results.html:145
 msgid "mechanism"
 msgstr "mechanizmas"
 
-#: app/templates/check_results.html:145
+#: app/templates/check_results.html:147
 msgid "mechanisms"
 msgstr "mechanizmai"
 
-#: app/templates/check_results.html:147
+#: app/templates/check_results.html:149
 msgid "out of"
 msgstr "iš"
 
-#: app/templates/check_results.html:150
-msgctxt "zero"
-msgid "configured"
-msgstr "sukonfigūruotas"
-
 #: app/templates/check_results.html:152
-msgctxt "singular"
+msgctxt "zero"
 msgid "configured"
 msgstr "sukonfigūruotas"
 
 #: app/templates/check_results.html:154
+msgctxt "singular"
+msgid "configured"
+msgstr "sukonfigūruotas"
+
+#: app/templates/check_results.html:156
 msgctxt "plural"
 msgid "configured"
 msgstr "sukonfigūruoti"
 
-#: app/templates/check_results.html:156
+#: app/templates/check_results.html:158
 msgid "without issues."
 msgstr "be klaidų."
 
-#: app/templates/check_results.html:173
+#: app/templates/check_results.html:175
 msgid "SPF: the record is optional"
 msgstr "SPF: įrašas neprivalomas"
 
-#: app/templates/check_results.html:177
+#: app/templates/check_results.html:179
 msgid ""
 "Because the DMARC record is configured correctly, the SPF record is not "
 "required. Sending e-mail messages from this domain without using the SPF "
@@ -216,7 +220,7 @@ msgstr ""
 "privalomas. Siunčiami pranešimai iš šio domeno nenaudojant SPF mechanizmą"
 " yra įmanomi - tokiu atveju žinutė turi turėti teisingą DKIM parašą."
 
-#: app/templates/check_results.html:184
+#: app/templates/check_results.html:186
 msgid ""
 "However, we recommend configuring an SPF record if possible (even if the "
 "domain is not used to send e-mails), because older mail servers may not "
@@ -230,62 +234,85 @@ msgstr ""
 " mechanizmų SPF, DKIM ir DMARC - kombinacija leidžia visiems serveriams "
 "tinkamai patikrinti el. pašto žinučių autentiškumą."
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:366
 msgid "Record"
 msgstr "Įrašas"
 
-#: app/templates/check_results.html:210 app/templates/check_results.html:250
+#: app/templates/check_results.html:212 app/templates/check_results.html:252
 msgid "Records"
 msgstr "Įrašai"
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:371
 msgid "Warnings"
 msgstr "Įspėjimai"
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:372
+#: app/templates/check_results.html:376 app/templates/check_results.html:384
 msgid "none"
 msgstr "nėra"
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:375
 msgid "Errors"
 msgstr "Klaidos"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:269 app/templates/check_results.html:379
 msgid "Additional information"
 msgstr ""
 
-#: app/templates/check_results.html:289
+#: app/templates/check_results.html:292
+msgid "Incoming mail"
+msgstr ""
+
+#: app/templates/check_results.html:297
 msgid "Preference"
 msgstr ""
 
-#: app/templates/check_results.html:291
+#: app/templates/check_results.html:299
 msgid "Server"
 msgstr ""
 
-#: app/templates/check_results.html:292
+#: app/templates/check_results.html:300
 msgid "Port"
 msgstr ""
 
-#: app/templates/check_results.html:293
+#: app/templates/check_results.html:301
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:327
+msgid "Outgoing mail"
+msgstr ""
+
+#: app/templates/check_results.html:333
+msgid "Your mail server delivered the test message over TLS."
+msgstr ""
+
+#: app/templates/check_results.html:335
+msgid "Your mail server delivered the test message without TLS."
+msgstr ""
+
+#: app/templates/check_results.html:337
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+
+#: app/templates/check_results.html:360
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:399
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -294,7 +321,7 @@ msgstr ""
 "interpretuojama visų el. pašto serverių, mes rekomenduojame ištaisyti "
 "visas klaidas ir perspėjimus. "
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:407
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/lt_LT/LC_MESSAGES/messages.po
+++ b/app/translations/lt_LT/LC_MESSAGES/messages.po
@@ -267,7 +267,7 @@ msgid "Additional information"
 msgstr ""
 
 #: app/templates/check_results.html:292
-msgid "Outgoing mail"
+msgid "Incoming mail"
 msgstr ""
 
 #: app/templates/check_results.html:297
@@ -291,7 +291,7 @@ msgid "Configuration valid"
 msgstr ""
 
 #: app/templates/check_results.html:339
-msgid "Incoming mail"
+msgid "Outgoing mail"
 msgstr ""
 
 #: app/templates/check_results.html:345

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -19,10 +19,10 @@ msgstr ""
 msgid "Check domain"
 msgstr ""
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:354
 msgid "Domain"
 msgstr ""
 
@@ -92,109 +92,113 @@ msgid "record couldn't be fully verified"
 msgstr ""
 
 #: app/templates/check_results.html:53
-msgid "configuration warnings"
+msgid "couldn't be tested"
 msgstr ""
 
 #: app/templates/check_results.html:55
+msgid "configuration warnings"
+msgstr ""
+
+#: app/templates/check_results.html:57
 msgid "correct configuration"
 msgstr ""
 
-#: app/templates/check_results.html:81
+#: app/templates/check_results.html:83
 msgid "e-mail sender verification mechanisms check results:"
 msgstr ""
 
-#: app/templates/check_results.html:83
+#: app/templates/check_results.html:85
 msgid "E-mail sender verification mechanisms check results:"
 msgstr ""
 
-#: app/templates/check_results.html:86
+#: app/templates/check_results.html:88
 msgid "SPF and DMARC"
 msgstr ""
 
-#: app/templates/check_results.html:87
+#: app/templates/check_results.html:89
 msgid "DKIM"
 msgstr ""
 
-#: app/templates/check_results.html:88
+#: app/templates/check_results.html:90
 msgid "SPF, DMARC and DKIM"
 msgstr ""
 
-#: app/templates/check_results.html:95
+#: app/templates/check_results.html:97
 #, python-format
 msgid ""
 "The results you are viewing are older than %(age_threshold_minutes)s "
 "minutes."
 msgstr ""
 
-#: app/templates/check_results.html:100
+#: app/templates/check_results.html:102
 #, python-format
 msgid ""
 "If you want to view up-to-date results, please <a "
 "href='%(rescan_url)s'>run a new check.</a>"
 msgstr ""
 
-#: app/templates/check_results.html:109
+#: app/templates/check_results.html:111
 msgid "Test date: "
 msgstr ""
 
-#: app/templates/check_results.html:110
+#: app/templates/check_results.html:112
 #, python-format
 msgid "(e-mail message from %(date_str)s)"
 msgstr ""
 
-#: app/templates/check_results.html:113
+#: app/templates/check_results.html:115
 msgid "To share check results, copy the following link:"
 msgstr ""
 
-#: app/templates/check_results.html:124
+#: app/templates/check_results.html:126
 msgid "Domain does not exist."
 msgstr ""
 
-#: app/templates/check_results.html:137
+#: app/templates/check_results.html:139
 msgid "Check summary"
 msgstr ""
 
-#: app/templates/check_results.html:141
+#: app/templates/check_results.html:143
 msgctxt "zero"
 msgid "mechanisms"
-msgstr ""
-
-#: app/templates/check_results.html:143
-msgid "mechanism"
 msgstr ""
 
 #: app/templates/check_results.html:145
-msgid "mechanisms"
+msgid "mechanism"
 msgstr ""
 
 #: app/templates/check_results.html:147
+msgid "mechanisms"
+msgstr ""
+
+#: app/templates/check_results.html:149
 msgid "out of"
 msgstr ""
 
-#: app/templates/check_results.html:150
-msgctxt "zero"
-msgid "configured"
-msgstr ""
-
 #: app/templates/check_results.html:152
-msgctxt "singular"
+msgctxt "zero"
 msgid "configured"
 msgstr ""
 
 #: app/templates/check_results.html:154
-msgctxt "plural"
+msgctxt "singular"
 msgid "configured"
 msgstr ""
 
 #: app/templates/check_results.html:156
+msgctxt "plural"
+msgid "configured"
+msgstr ""
+
+#: app/templates/check_results.html:158
 msgid "without issues."
 msgstr ""
 
-#: app/templates/check_results.html:173
+#: app/templates/check_results.html:175
 msgid "SPF: the record is optional"
 msgstr ""
 
-#: app/templates/check_results.html:177
+#: app/templates/check_results.html:179
 msgid ""
 "Because the DMARC record is configured correctly, the SPF record is not "
 "required. Sending e-mail messages from this domain without using the SPF "
@@ -202,7 +206,7 @@ msgid ""
 "correct DKIM signatures."
 msgstr ""
 
-#: app/templates/check_results.html:184
+#: app/templates/check_results.html:186
 msgid ""
 "However, we recommend configuring an SPF record if possible (even if the "
 "domain is not used to send e-mails), because older mail servers may not "
@@ -211,68 +215,91 @@ msgid ""
 "properly verify e-mail message authenticity."
 msgstr ""
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:366
 msgid "Record"
 msgstr ""
 
-#: app/templates/check_results.html:210 app/templates/check_results.html:250
+#: app/templates/check_results.html:212 app/templates/check_results.html:252
 msgid "Records"
 msgstr ""
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:371
 msgid "Warnings"
 msgstr ""
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:372
+#: app/templates/check_results.html:376 app/templates/check_results.html:384
 msgid "none"
 msgstr ""
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:375
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:269 app/templates/check_results.html:379
 msgid "Additional information"
 msgstr ""
 
-#: app/templates/check_results.html:289
+#: app/templates/check_results.html:292
+msgid "Incoming mail"
+msgstr ""
+
+#: app/templates/check_results.html:297
 msgid "Preference"
 msgstr ""
 
-#: app/templates/check_results.html:291
+#: app/templates/check_results.html:299
 msgid "Server"
 msgstr ""
 
-#: app/templates/check_results.html:292
+#: app/templates/check_results.html:300
 msgid "Port"
 msgstr ""
 
-#: app/templates/check_results.html:293
+#: app/templates/check_results.html:301
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:327
+msgid "Outgoing mail"
+msgstr ""
+
+#: app/templates/check_results.html:333
+msgid "Your mail server delivered the test message over TLS."
+msgstr ""
+
+#: app/templates/check_results.html:335
+msgid "Your mail server delivered the test message without TLS."
+msgstr ""
+
+#: app/templates/check_results.html:337
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+
+#: app/templates/check_results.html:360
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:399
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:407
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -248,7 +248,7 @@ msgid "Additional information"
 msgstr ""
 
 #: app/templates/check_results.html:292
-msgid "Outgoing mail"
+msgid "Incoming mail"
 msgstr ""
 
 #: app/templates/check_results.html:297
@@ -272,7 +272,7 @@ msgid "Configuration valid"
 msgstr ""
 
 #: app/templates/check_results.html:339
-msgid "Incoming mail"
+msgid "Outgoing mail"
 msgstr ""
 
 #: app/templates/check_results.html:345

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -19,10 +19,10 @@ msgstr ""
 msgid "Check domain"
 msgstr ""
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:338
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:366
 msgid "Domain"
 msgstr ""
 
@@ -215,9 +215,9 @@ msgid ""
 "properly verify e-mail message authenticity."
 msgstr ""
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:350
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:378
 msgid "Record"
 msgstr ""
 
@@ -225,30 +225,30 @@ msgstr ""
 msgid "Records"
 msgstr ""
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:313 app/templates/check_results.html:355
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:321 app/templates/check_results.html:383
 msgid "Warnings"
 msgstr ""
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:356
-#: app/templates/check_results.html:360 app/templates/check_results.html:368
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:384
+#: app/templates/check_results.html:388 app/templates/check_results.html:396
 msgid "none"
 msgstr ""
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:309 app/templates/check_results.html:359
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:317 app/templates/check_results.html:387
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:317
-#: app/templates/check_results.html:363
+#: app/templates/check_results.html:269 app/templates/check_results.html:325
+#: app/templates/check_results.html:391
 msgid "Additional information"
 msgstr ""
 
 #: app/templates/check_results.html:292
-msgid "Incoming mail"
+msgid "Outgoing mail"
 msgstr ""
 
 #: app/templates/check_results.html:297
@@ -267,21 +267,40 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:306
+#: app/templates/check_results.html:314
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:344
+#: app/templates/check_results.html:339
+msgid "Incoming mail"
+msgstr ""
+
+#: app/templates/check_results.html:345
+msgid "Your mail server delivered the test message over TLS."
+msgstr ""
+
+#: app/templates/check_results.html:347
+msgid "Your mail server delivered the test message without TLS."
+msgstr ""
+
+#: app/templates/check_results.html:349
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+
+#: app/templates/check_results.html:372
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:383
+#: app/templates/check_results.html:411
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:391
+#: app/templates/check_results.html:419
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/app/translations/pl_PL/LC_MESSAGES/messages.po
@@ -19,10 +19,10 @@ msgstr "Skopiowano"
 msgid "Check domain"
 msgstr "Sprawdź domenę"
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:338
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:366
 msgid "Domain"
 msgstr "Domena"
 
@@ -237,9 +237,9 @@ msgstr ""
 "DMARC umożliwi innym serwerom na poprawne zweryfikowanie wiadomości we "
 "wszystkich przypadkach."
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:350
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:378
 msgid "Record"
 msgstr "Rekord"
 
@@ -247,31 +247,31 @@ msgstr "Rekord"
 msgid "Records"
 msgstr "Rekordy"
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:313 app/templates/check_results.html:355
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:321 app/templates/check_results.html:383
 msgid "Warnings"
 msgstr "Ostrzeżenia"
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:356
-#: app/templates/check_results.html:360 app/templates/check_results.html:368
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:384
+#: app/templates/check_results.html:388 app/templates/check_results.html:396
 msgid "none"
 msgstr "brak"
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:309 app/templates/check_results.html:359
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:317 app/templates/check_results.html:387
 msgid "Errors"
 msgstr "Błędy"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:317
-#: app/templates/check_results.html:363
+#: app/templates/check_results.html:269 app/templates/check_results.html:325
+#: app/templates/check_results.html:391
 msgid "Additional information"
 msgstr "Dodatkowe informacje"
 
 #: app/templates/check_results.html:292
-msgid "Incoming mail"
-msgstr "Poczta przychodząca"
+msgid "Outgoing mail"
+msgstr "Poczta wychodząca"
 
 #: app/templates/check_results.html:297
 msgid "Preference"
@@ -289,15 +289,36 @@ msgstr "Port"
 msgid "Result"
 msgstr "Wynik"
 
-#: app/templates/check_results.html:306
+#: app/templates/check_results.html:314
 msgid "Configuration valid"
 msgstr "Konfiguracja prawidłowa"
 
-#: app/templates/check_results.html:344
+#: app/templates/check_results.html:339
+msgid "Incoming mail"
+msgstr "Poczta przychodząca"
+
+#: app/templates/check_results.html:345
+msgid "Your mail server delivered the test message over TLS."
+msgstr "Twój serwer pocztowy dostarczył testową wiadomość e-mail przy użyciu TLS."
+
+#: app/templates/check_results.html:347
+msgid "Your mail server delivered the test message without TLS."
+msgstr "Twój serwer pocztowy dostarczył testową wiadomość e-mail bez użycia TLS."
+
+#: app/templates/check_results.html:349
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+"Nie można było przetestować obsługi TLS - ta instancja nie jest skonfigurowana z "
+"certyfikatem TLS, więc nadawca nie mógłby użyć TLS."
+
+#: app/templates/check_results.html:372
 msgid "Selector"
 msgstr "Selektor"
 
-#: app/templates/check_results.html:383
+#: app/templates/check_results.html:411
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -306,7 +327,7 @@ msgstr ""
 "zinterpretowana przez wszystkie serwery, rekomendujemy poprawę zarówno "
 "błędów, jak i ostrzeżeń."
 
-#: app/templates/check_results.html:391
+#: app/templates/check_results.html:419
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/app/translations/pl_PL/LC_MESSAGES/messages.po
@@ -270,8 +270,8 @@ msgid "Additional information"
 msgstr "Dodatkowe informacje"
 
 #: app/templates/check_results.html:292
-msgid "Outgoing mail"
-msgstr "Poczta wychodząca"
+msgid "Incoming mail"
+msgstr "Poczta przychodząca"
 
 #: app/templates/check_results.html:297
 msgid "Preference"
@@ -294,8 +294,8 @@ msgid "Configuration valid"
 msgstr "Konfiguracja prawidłowa"
 
 #: app/templates/check_results.html:339
-msgid "Incoming mail"
-msgstr "Poczta przychodząca"
+msgid "Outgoing mail"
+msgstr "Poczta wychodząca"
 
 #: app/templates/check_results.html:345
 msgid "Your mail server delivered the test message over TLS."
@@ -311,8 +311,8 @@ msgid ""
 "TLS certificate, so the sender couldn't have used TLS even if they wanted"
 " to."
 msgstr ""
-"Nie można było przetestować obsługi TLS - ta instancja nie jest skonfigurowana z "
-"certyfikatem TLS, więc nadawca nie mógłby użyć TLS."
+"Nie można było przetestować obsługi TLS - ta instancja nie jest "
+"skonfigurowana z certyfikatem TLS, więc nadawca nie mógłby użyć TLS."
 
 #: app/templates/check_results.html:372
 msgid "Selector"

--- a/app/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/app/translations/pl_PL/LC_MESSAGES/messages.po
@@ -19,10 +19,10 @@ msgstr "Skopiowano"
 msgid "Check domain"
 msgstr "Sprawdź domenę"
 
-#: app/templates/check_domain.html:12 app/templates/check_results.html:74
-#: app/templates/check_results.html:76 app/templates/check_results.html:78
-#: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_domain.html:12 app/templates/check_results.html:76
+#: app/templates/check_results.html:78 app/templates/check_results.html:80
+#: app/templates/check_results.html:201 app/templates/check_results.html:241
+#: app/templates/check_results.html:354
 msgid "Domain"
 msgstr "Domena"
 
@@ -100,41 +100,45 @@ msgid "record couldn't be fully verified"
 msgstr "rekord nie mógł być w pełni sprawdzony"
 
 #: app/templates/check_results.html:53
+msgid "couldn't be tested"
+msgstr "brak możliwości przetestowania"
+
+#: app/templates/check_results.html:55
 msgid "configuration warnings"
 msgstr "uwagi dotyczące konfiguracji"
 
-#: app/templates/check_results.html:55
+#: app/templates/check_results.html:57
 msgid "correct configuration"
 msgstr "konfiguracja prawidłowa"
 
-#: app/templates/check_results.html:81
+#: app/templates/check_results.html:83
 msgid "e-mail sender verification mechanisms check results:"
 msgstr "wyniki testów mechanizmów zabezpieczeń poczty e-mail:"
 
-#: app/templates/check_results.html:83
+#: app/templates/check_results.html:85
 msgid "E-mail sender verification mechanisms check results:"
 msgstr "Wyniki testów mechanizmów zabezpieczeń poczty e-mail:"
 
-#: app/templates/check_results.html:86
+#: app/templates/check_results.html:88
 msgid "SPF and DMARC"
 msgstr "SPF i DMARC"
 
-#: app/templates/check_results.html:87
+#: app/templates/check_results.html:89
 msgid "DKIM"
 msgstr "DKIM"
 
-#: app/templates/check_results.html:88
+#: app/templates/check_results.html:90
 msgid "SPF, DMARC and DKIM"
 msgstr "SPF, DMARC i DKIM"
 
-#: app/templates/check_results.html:95
+#: app/templates/check_results.html:97
 #, python-format
 msgid ""
 "The results you are viewing are older than %(age_threshold_minutes)s "
 "minutes."
 msgstr "Oglądają Państwo wyniki starsze niż %(age_threshold_minutes)s minut."
 
-#: app/templates/check_results.html:100
+#: app/templates/check_results.html:102
 #, python-format
 msgid ""
 "If you want to view up-to-date results, please <a "
@@ -143,70 +147,70 @@ msgstr ""
 "Jeśli chcą Państwo uzyskać najnowsze wyniki, prosimy <a "
 "href='%(rescan_url)s'>wykonać ponowne sprawdzenie.</a>"
 
-#: app/templates/check_results.html:109
+#: app/templates/check_results.html:111
 msgid "Test date: "
 msgstr "Data sprawdzenia: "
 
-#: app/templates/check_results.html:110
+#: app/templates/check_results.html:112
 #, python-format
 msgid "(e-mail message from %(date_str)s)"
 msgstr "(wiadomość e-mail z %(date_str)s)"
 
-#: app/templates/check_results.html:113
+#: app/templates/check_results.html:115
 msgid "To share check results, copy the following link:"
 msgstr ""
 "Jeśli chcą Państwo udostępnić wyniki sprawdzenia, prosimy skopiować ten "
 "link:"
 
-#: app/templates/check_results.html:124
+#: app/templates/check_results.html:126
 msgid "Domain does not exist."
 msgstr "Domena nie istnieje."
 
-#: app/templates/check_results.html:137
+#: app/templates/check_results.html:139
 msgid "Check summary"
 msgstr "Podsumowanie sprawdzenia"
 
-#: app/templates/check_results.html:141
+#: app/templates/check_results.html:143
 msgctxt "zero"
 msgid "mechanisms"
 msgstr "mechanizmów"
 
-#: app/templates/check_results.html:143
+#: app/templates/check_results.html:145
 msgid "mechanism"
 msgstr "mechanizm"
 
-#: app/templates/check_results.html:145
+#: app/templates/check_results.html:147
 msgid "mechanisms"
 msgstr "mechanizmy"
 
-#: app/templates/check_results.html:147
+#: app/templates/check_results.html:149
 msgid "out of"
 msgstr "z"
 
-#: app/templates/check_results.html:150
+#: app/templates/check_results.html:152
 msgctxt "zero"
 msgid "configured"
 msgstr "skonfigurowanych"
 
-#: app/templates/check_results.html:152
+#: app/templates/check_results.html:154
 msgctxt "singular"
 msgid "configured"
 msgstr "skonfigurowany"
 
-#: app/templates/check_results.html:154
+#: app/templates/check_results.html:156
 msgctxt "plural"
 msgid "configured"
 msgstr "skonfigurowane"
 
-#: app/templates/check_results.html:156
+#: app/templates/check_results.html:158
 msgid "without issues."
 msgstr "bez zastrzeżeń."
 
-#: app/templates/check_results.html:173
+#: app/templates/check_results.html:175
 msgid "SPF: the record is optional"
 msgstr "SPF: rekord opcjonalny"
 
-#: app/templates/check_results.html:177
+#: app/templates/check_results.html:179
 msgid ""
 "Because the DMARC record is configured correctly, the SPF record is not "
 "required. Sending e-mail messages from this domain without using the SPF "
@@ -218,7 +222,7 @@ msgstr ""
 "mechanizmu SPF nadal jest możliwe - w takiej sytuacji wiadomości muszą "
 "posiadać poprawny podpis DKIM."
 
-#: app/templates/check_results.html:184
+#: app/templates/check_results.html:186
 msgid ""
 "However, we recommend configuring an SPF record if possible (even if the "
 "domain is not used to send e-mails), because older mail servers may not "
@@ -233,62 +237,92 @@ msgstr ""
 "DMARC umożliwi innym serwerom na poprawne zweryfikowanie wiadomości we "
 "wszystkich przypadkach."
 
-#: app/templates/check_results.html:205 app/templates/check_results.html:210
-#: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:207 app/templates/check_results.html:212
+#: app/templates/check_results.html:247 app/templates/check_results.html:252
+#: app/templates/check_results.html:366
 msgid "Record"
 msgstr "Rekord"
 
-#: app/templates/check_results.html:210 app/templates/check_results.html:250
+#: app/templates/check_results.html:212 app/templates/check_results.html:252
 msgid "Records"
 msgstr "Rekordy"
 
-#: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:221 app/templates/check_results.html:261
+#: app/templates/check_results.html:371
 msgid "Warnings"
 msgstr "Ostrzeżenia"
 
-#: app/templates/check_results.html:220 app/templates/check_results.html:224
-#: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:222 app/templates/check_results.html:226
+#: app/templates/check_results.html:262 app/templates/check_results.html:266
+#: app/templates/check_results.html:274 app/templates/check_results.html:372
+#: app/templates/check_results.html:376 app/templates/check_results.html:384
 msgid "none"
 msgstr "brak"
 
-#: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:225 app/templates/check_results.html:265
+#: app/templates/check_results.html:375
 msgid "Errors"
 msgstr "Błędy"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:269 app/templates/check_results.html:379
 msgid "Additional information"
 msgstr "Dodatkowe informacje"
 
-#: app/templates/check_results.html:289
+#: app/templates/check_results.html:292
+msgid "Incoming mail"
+msgstr "Poczta przychodząca"
+
+#: app/templates/check_results.html:297
 msgid "Preference"
 msgstr "Priorytet"
 
-#: app/templates/check_results.html:291
+#: app/templates/check_results.html:299
 msgid "Server"
 msgstr "Serwer"
 
-#: app/templates/check_results.html:292
+#: app/templates/check_results.html:300
 msgid "Port"
 msgstr "Port"
 
-#: app/templates/check_results.html:293
+#: app/templates/check_results.html:301
 msgid "Result"
 msgstr "Wynik"
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr "Konfiguracja prawidłowa"
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:327
+msgid "Outgoing mail"
+msgstr "Poczta wychodząca"
+
+#: app/templates/check_results.html:333
+msgid "Your mail server delivered the test message over TLS."
+msgstr ""
+"Twój serwer pocztowy dostarczył wiadomość testową z wykorzystaniem "
+"protokołu TLS."
+
+#: app/templates/check_results.html:335
+msgid "Your mail server delivered the test message without TLS."
+msgstr ""
+"Twój serwer pocztowy dostarczył wiadomość testową bez wykorzystania "
+"protokołu TLS."
+
+#: app/templates/check_results.html:337
+msgid ""
+"TLS support couldn't be tested - this instance is not configured with a "
+"TLS certificate, so the sender couldn't have used TLS even if they wanted"
+" to."
+msgstr ""
+"Wsparcie dla TLS nie mogło zostać zweryfikowane - ta instancja nie "
+"posiada skonfigurowanego certyfikatu TLS, a więc nadawca wiadomości nie "
+"mógłby użyć TLS, nawet gdyby chciał to zrobić."
+
+#: app/templates/check_results.html:360
 msgid "Selector"
 msgstr "Selektor"
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:399
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -297,7 +331,7 @@ msgstr ""
 "zinterpretowana przez wszystkie serwery, rekomendujemy poprawę zarówno "
 "błędów, jak i ostrzeżeń."
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:407
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/mail_receiver/server.py
+++ b/mail_receiver/server.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, Sequence, Union
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import Message as BaseMessageHandler
 from aiosmtpd.smtp import SMTP, Envelope, Session
+from libmailgoose.scan import IncomingTLSStatus
 from redis import Redis
 
 from common.config import Config
@@ -49,7 +50,14 @@ class RedisHandler(BaseMessageHandler):
         # don't break DKIM body hash.
         content = envelope.original_content or b""
 
+        if SSL_CONTEXT is None:
+            tls_status = IncomingTLSStatus.NOT_TESTABLE
+        elif session.ssl is not None:
+            tls_status = IncomingTLSStatus.USED
+        else:
+            tls_status = IncomingTLSStatus.NOT_USED
         LOGGER.info("SSL: %s", session.ssl)
+
         LOGGER.info(
             "Raw message body bytes (hexlified): %s",
             binascii.hexlify(content),
@@ -86,6 +94,11 @@ class RedisHandler(BaseMessageHandler):
                     key + b"-sender",
                     Config.Data.REDIS_MESSAGE_DATA_EXPIRY_SECONDS,
                     mail_from,
+                )
+                REDIS.setex(
+                    key + b"-tls",
+                    Config.Data.REDIS_MESSAGE_DATA_EXPIRY_SECONDS,
+                    tls_status.value,
                 )
                 LOGGER.info("Saved")
             except Exception:

--- a/scan/libmailgoose/scan.py
+++ b/scan/libmailgoose/scan.py
@@ -1,4 +1,5 @@
 import datetime
+import enum
 import io
 import string
 import subprocess
@@ -101,12 +102,19 @@ class DKIMScanResult:
     additional_info: List[str]
 
 
+class IncomingTLSStatus(str, enum.Enum):
+    USED = "used"
+    NOT_USED = "not_used"
+    NOT_TESTABLE = "not_testable"
+
+
 @dataclass
 class ScanResult:
     domain: Optional[DomainScanResult]
     dkim: Optional[DKIMScanResult]
     timestamp: Optional[datetime.datetime]
     message_timestamp: Optional[datetime.datetime]
+    incoming_tls_status: Optional[IncomingTLSStatus] = None
 
     @property
     def num_checked_mechanisms(self) -> int:
@@ -738,6 +746,7 @@ def scan(
     message: Optional[bytes],
     message_sender_ip: Optional[bytes],
     message_timestamp: Optional[datetime.datetime],
+    incoming_tls_status: Optional[IncomingTLSStatus] = None,
     nameservers: Optional[List[str]] = None,
     dkim_implementation_mismatch_callback: Optional[Callable[[bytes, bool, bool], None]] = None,
 ) -> ScanResult:
@@ -766,4 +775,5 @@ def scan(
         ),
         timestamp=datetime.datetime.now(),
         message_timestamp=message_timestamp,
+        incoming_tls_status=incoming_tls_status,
     )

--- a/scan/libmailgoose/translate.py
+++ b/scan/libmailgoose/translate.py
@@ -1624,4 +1624,5 @@ def translate_scan_result(
         ),
         timestamp=scan_result.timestamp,
         message_timestamp=scan_result.message_timestamp,
+        incoming_tls_status=scan_result.incoming_tls_status,
     )


### PR DESCRIPTION
I have added a sub-section displaying whether STARTTLS has been used by the MTA which connected to `mail_receiver` in order to deliver the test message.

---

Polish:

<img width="1450" height="457" alt="x1" src="https://github.com/user-attachments/assets/4a3fceed-4b2a-40ff-8bf4-a94369e62c3d" />
<img width="1451" height="455" alt="x2" src="https://github.com/user-attachments/assets/5320dc8b-b2ab-4a06-a5c5-002a90ea8c99" />
<img width="1447" height="478" alt="x3" src="https://github.com/user-attachments/assets/979d3120-866d-4539-a67f-e5c6c6d1f42a" />

---

English:

<img width="1447" height="451" alt="x4" src="https://github.com/user-attachments/assets/55d747e9-0b00-473f-8688-0ca80961c4f6" />
<img width="1446" height="454" alt="x5" src="https://github.com/user-attachments/assets/93e5c618-147e-42dc-9bd2-1ed74dd4505b" />
<img width="1447" height="453" alt="x6" src="https://github.com/user-attachments/assets/56b5534e-5929-416f-84ad-c99d8ce587c6" />
