### PR TITLE
Explain SSL/TLS Certificates if certificate error occurs

### DIFF
--- a/app/templates/check_results.html
+++ b/app/templates/check_results.html
@@ -301,9 +301,17 @@
                                                 <td class="d-none d-sm-table-cell">{{ item.mx }}</td>
                                                 <td class="d-none d-sm-table-cell">{% if item.port %}{{ item.port }}{% else %}-{% endif %}</td>
                                                 {% if item.error %}
-                                                    <td class="text-danger">{{ item.error }}</td>
+                                                    <td class="text-danger">{{ item.error }}
+                                                    {% if item.additional_info %}
+                                                        <p>{{ item.additional_info }}</p>
+                                                    {% endif %}
+                                                    </td>
                                                 {% elif item.warning %}
-                                                    <td class="text-warning-dark">{{ item.warning }}</td>
+                                                    <td class="text-warning-dark">{{ item.warning }}
+                                                    {% if item.additional_info %}
+                                                        <p>{{ item.additional_info }}</p>
+                                                    {% endif %}
+                                                    </td>
                                                 {% else %}
                                                     <td class="text-success">{% trans %}Configuration valid{% endtrans %}</td>
                                                 {% endif %}

--- a/app/templates/check_results.html
+++ b/app/templates/check_results.html
@@ -300,21 +300,25 @@
                                                 <td class="d-table-cell d-sm-none">{{ item.mx }}:{% if item.port %}{{ item.port }}{% else %}-{% endif %}</td>
                                                 <td class="d-none d-sm-table-cell">{{ item.mx }}</td>
                                                 <td class="d-none d-sm-table-cell">{% if item.port %}{{ item.port }}{% else %}-{% endif %}</td>
-                                                {% if item.error %}
-                                                    <td class="text-danger">{{ item.error }}
-                                                    {% if item.additional_info %}
-                                                        <p>{{ item.additional_info }}</p>
-                                                    {% endif %}
-                                                    </td>
-                                                {% elif item.warning %}
-                                                    <td class="text-warning-dark">{{ item.warning }}
-                                                    {% if item.additional_info %}
-                                                        <p>{{ item.additional_info }}</p>
-                                                    {% endif %}
-                                                    </td>
+                                                <td>
+
+                                                {% if not item.error and not item.warning %}
+                                                    <p class="text-success mb-0">{% trans %}Configuration valid{% endtrans %}</p>
                                                 {% else %}
-                                                    <td class="text-success">{% trans %}Configuration valid{% endtrans %}</td>
+                                                    {% if item.error %}
+                                                        <b class="text-danger">{% trans %}Errors{% endtrans %}:</b>
+                                                        <p class="mb-0">{{ item.error }}</p>
+                                                    {% endif %}
+                                                    {% if item.warning %}
+                                                        <b class="text-warning-dark">{% trans %}Warnings{% endtrans %}:</b>
+                                                        <p class="mb-0">{{ item.warning }}</p>
+                                                    {% endif %}
+                                                    {% if item.additional_info %}
+                                                        <b>{% trans %}Additional information{% endtrans %}:</b>
+                                                        <p class="mb-0">{{ item.additional_info }}</p>
+                                                    {% endif %}
                                                 {% endif %}
+                                                </td>
                                             </tr>
                                         {% endfor %}
                                     </tbody>

--- a/app/translations/en_US/LC_MESSAGES/messages.po
+++ b/app/translations/en_US/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_results.html:334
 msgid "Domain"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:346
 msgid "Record"
 msgstr ""
 
@@ -222,23 +222,23 @@ msgid "Records"
 msgstr ""
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:351
 msgid "Warnings"
 msgstr ""
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:272 app/templates/check_results.html:352
+#: app/templates/check_results.html:356 app/templates/check_results.html:364
 msgid "none"
 msgstr ""
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:355
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:267 app/templates/check_results.html:359
 msgid "Additional information"
 msgstr ""
 
@@ -258,21 +258,21 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:340
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:379
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:387
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/en_US/LC_MESSAGES/messages.po
+++ b/app/translations/en_US/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:334
+#: app/templates/check_results.html:338
 msgid "Domain"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:346
+#: app/templates/check_results.html:350
 msgid "Record"
 msgstr ""
 
@@ -222,23 +222,24 @@ msgid "Records"
 msgstr ""
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:351
+#: app/templates/check_results.html:313 app/templates/check_results.html:355
 msgid "Warnings"
 msgstr ""
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:352
-#: app/templates/check_results.html:356 app/templates/check_results.html:364
+#: app/templates/check_results.html:272 app/templates/check_results.html:356
+#: app/templates/check_results.html:360 app/templates/check_results.html:368
 msgid "none"
 msgstr ""
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:355
+#: app/templates/check_results.html:309 app/templates/check_results.html:359
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:359
+#: app/templates/check_results.html:267 app/templates/check_results.html:317
+#: app/templates/check_results.html:363
 msgid "Additional information"
 msgstr ""
 
@@ -258,21 +259,21 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:316
+#: app/templates/check_results.html:306
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:340
+#: app/templates/check_results.html:344
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:383
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:387
+#: app/templates/check_results.html:391
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/lt_LT/LC_MESSAGES/messages.po
+++ b/app/translations/lt_LT/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr "Tikrinti domeną"
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:334
+#: app/templates/check_results.html:338
 msgid "Domain"
 msgstr "Domenas"
 
@@ -232,7 +232,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:346
+#: app/templates/check_results.html:350
 msgid "Record"
 msgstr "Įrašas"
 
@@ -241,23 +241,24 @@ msgid "Records"
 msgstr "Įrašai"
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:351
+#: app/templates/check_results.html:313 app/templates/check_results.html:355
 msgid "Warnings"
 msgstr "Įspėjimai"
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:352
-#: app/templates/check_results.html:356 app/templates/check_results.html:364
+#: app/templates/check_results.html:272 app/templates/check_results.html:356
+#: app/templates/check_results.html:360 app/templates/check_results.html:368
 msgid "none"
 msgstr "nėra"
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:355
+#: app/templates/check_results.html:309 app/templates/check_results.html:359
 msgid "Errors"
 msgstr "Klaidos"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:359
+#: app/templates/check_results.html:267 app/templates/check_results.html:317
+#: app/templates/check_results.html:363
 msgid "Additional information"
 msgstr ""
 
@@ -277,15 +278,15 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:316
+#: app/templates/check_results.html:306
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:340
+#: app/templates/check_results.html:344
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:383
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -294,7 +295,7 @@ msgstr ""
 "interpretuojama visų el. pašto serverių, mes rekomenduojame ištaisyti "
 "visas klaidas ir perspėjimus. "
 
-#: app/templates/check_results.html:387
+#: app/templates/check_results.html:391
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/lt_LT/LC_MESSAGES/messages.po
+++ b/app/translations/lt_LT/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr "Tikrinti domeną"
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_results.html:334
 msgid "Domain"
 msgstr "Domenas"
 
@@ -232,7 +232,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:346
 msgid "Record"
 msgstr "Įrašas"
 
@@ -241,23 +241,23 @@ msgid "Records"
 msgstr "Įrašai"
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:351
 msgid "Warnings"
 msgstr "Įspėjimai"
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:272 app/templates/check_results.html:352
+#: app/templates/check_results.html:356 app/templates/check_results.html:364
 msgid "none"
 msgstr "nėra"
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:355
 msgid "Errors"
 msgstr "Klaidos"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:267 app/templates/check_results.html:359
 msgid "Additional information"
 msgstr ""
 
@@ -277,15 +277,15 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:340
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:379
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -294,7 +294,7 @@ msgstr ""
 "interpretuojama visų el. pašto serverių, mes rekomenduojame ištaisyti "
 "visas klaidas ir perspėjimus. "
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:387
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -22,7 +22,7 @@ msgstr ""
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_results.html:334
 msgid "Domain"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:346
 msgid "Record"
 msgstr ""
 
@@ -222,23 +222,23 @@ msgid "Records"
 msgstr ""
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:351
 msgid "Warnings"
 msgstr ""
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:272 app/templates/check_results.html:352
+#: app/templates/check_results.html:356 app/templates/check_results.html:364
 msgid "none"
 msgstr ""
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:355
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:267 app/templates/check_results.html:359
 msgid "Additional information"
 msgstr ""
 
@@ -258,21 +258,21 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:340
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:379
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:387
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/messages.pot
+++ b/app/translations/messages.pot
@@ -22,7 +22,7 @@ msgstr ""
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:334
+#: app/templates/check_results.html:338
 msgid "Domain"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:346
+#: app/templates/check_results.html:350
 msgid "Record"
 msgstr ""
 
@@ -222,23 +222,24 @@ msgid "Records"
 msgstr ""
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:351
+#: app/templates/check_results.html:313 app/templates/check_results.html:355
 msgid "Warnings"
 msgstr ""
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:352
-#: app/templates/check_results.html:356 app/templates/check_results.html:364
+#: app/templates/check_results.html:272 app/templates/check_results.html:356
+#: app/templates/check_results.html:360 app/templates/check_results.html:368
 msgid "none"
 msgstr ""
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:355
+#: app/templates/check_results.html:309 app/templates/check_results.html:359
 msgid "Errors"
 msgstr ""
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:359
+#: app/templates/check_results.html:267 app/templates/check_results.html:317
+#: app/templates/check_results.html:363
 msgid "Additional information"
 msgstr ""
 
@@ -258,21 +259,21 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: app/templates/check_results.html:316
+#: app/templates/check_results.html:306
 msgid "Configuration valid"
 msgstr ""
 
-#: app/templates/check_results.html:340
+#: app/templates/check_results.html:344
 msgid "Selector"
 msgstr ""
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:383
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
 msgstr ""
 
-#: app/templates/check_results.html:387
+#: app/templates/check_results.html:391
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/app/translations/pl_PL/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr "Sprawdź domenę"
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:326
+#: app/templates/check_results.html:334
 msgid "Domain"
 msgstr "Domena"
 
@@ -235,7 +235,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:338
+#: app/templates/check_results.html:346
 msgid "Record"
 msgstr "Rekord"
 
@@ -244,23 +244,23 @@ msgid "Records"
 msgstr "Rekordy"
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:343
+#: app/templates/check_results.html:351
 msgid "Warnings"
 msgstr "Ostrzeżenia"
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:344
-#: app/templates/check_results.html:348 app/templates/check_results.html:356
+#: app/templates/check_results.html:272 app/templates/check_results.html:352
+#: app/templates/check_results.html:356 app/templates/check_results.html:364
 msgid "none"
 msgstr "brak"
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:347
+#: app/templates/check_results.html:355
 msgid "Errors"
 msgstr "Błędy"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:351
+#: app/templates/check_results.html:267 app/templates/check_results.html:359
 msgid "Additional information"
 msgstr "Dodatkowe informacje"
 
@@ -280,15 +280,15 @@ msgstr "Port"
 msgid "Result"
 msgstr "Wynik"
 
-#: app/templates/check_results.html:308
+#: app/templates/check_results.html:316
 msgid "Configuration valid"
 msgstr "Konfiguracja prawidłowa"
 
-#: app/templates/check_results.html:332
+#: app/templates/check_results.html:340
 msgid "Selector"
 msgstr "Selektor"
 
-#: app/templates/check_results.html:371
+#: app/templates/check_results.html:379
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -297,7 +297,7 @@ msgstr ""
 "zinterpretowana przez wszystkie serwery, rekomendujemy poprawę zarówno "
 "błędów, jak i ostrzeżeń."
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:387
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/app/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/app/translations/pl_PL/LC_MESSAGES/messages.po
@@ -22,7 +22,7 @@ msgstr "Sprawdź domenę"
 #: app/templates/check_domain.html:12 app/templates/check_results.html:74
 #: app/templates/check_results.html:76 app/templates/check_results.html:78
 #: app/templates/check_results.html:199 app/templates/check_results.html:239
-#: app/templates/check_results.html:334
+#: app/templates/check_results.html:338
 msgid "Domain"
 msgstr "Domena"
 
@@ -235,7 +235,7 @@ msgstr ""
 
 #: app/templates/check_results.html:205 app/templates/check_results.html:210
 #: app/templates/check_results.html:245 app/templates/check_results.html:250
-#: app/templates/check_results.html:346
+#: app/templates/check_results.html:350
 msgid "Record"
 msgstr "Rekord"
 
@@ -244,23 +244,24 @@ msgid "Records"
 msgstr "Rekordy"
 
 #: app/templates/check_results.html:219 app/templates/check_results.html:259
-#: app/templates/check_results.html:351
+#: app/templates/check_results.html:313 app/templates/check_results.html:355
 msgid "Warnings"
 msgstr "Ostrzeżenia"
 
 #: app/templates/check_results.html:220 app/templates/check_results.html:224
 #: app/templates/check_results.html:260 app/templates/check_results.html:264
-#: app/templates/check_results.html:272 app/templates/check_results.html:352
-#: app/templates/check_results.html:356 app/templates/check_results.html:364
+#: app/templates/check_results.html:272 app/templates/check_results.html:356
+#: app/templates/check_results.html:360 app/templates/check_results.html:368
 msgid "none"
 msgstr "brak"
 
 #: app/templates/check_results.html:223 app/templates/check_results.html:263
-#: app/templates/check_results.html:355
+#: app/templates/check_results.html:309 app/templates/check_results.html:359
 msgid "Errors"
 msgstr "Błędy"
 
-#: app/templates/check_results.html:267 app/templates/check_results.html:359
+#: app/templates/check_results.html:267 app/templates/check_results.html:317
+#: app/templates/check_results.html:363
 msgid "Additional information"
 msgstr "Dodatkowe informacje"
 
@@ -280,15 +281,15 @@ msgstr "Port"
 msgid "Result"
 msgstr "Wynik"
 
-#: app/templates/check_results.html:316
+#: app/templates/check_results.html:306
 msgid "Configuration valid"
 msgstr "Konfiguracja prawidłowa"
 
-#: app/templates/check_results.html:340
+#: app/templates/check_results.html:344
 msgid "Selector"
 msgstr "Selektor"
 
-#: app/templates/check_results.html:379
+#: app/templates/check_results.html:383
 msgid ""
 "To increase the chance that your configuration is interpreted by all "
 "e-mail servers correctly, we recommend fixing all errors and warnings."
@@ -297,7 +298,7 @@ msgstr ""
 "zinterpretowana przez wszystkie serwery, rekomendujemy poprawę zarówno "
 "błędów, jak i ostrzeżeń."
 
-#: app/templates/check_results.html:387
+#: app/templates/check_results.html:391
 msgid ""
 "After fixing the issues, please rerun the scan - some problems can be "
 "detected only if earlier checks complete successfully."

--- a/scan/libmailgoose/ssl_check.py
+++ b/scan/libmailgoose/ssl_check.py
@@ -22,6 +22,7 @@ class SSLMXScanResult:
     port: Optional[int]
     error: Optional[str] = None
     warning: Optional[str] = None
+    additional_info: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -38,6 +39,7 @@ class SSLInternalError(Exception):
 class SSLCertificateError(Exception):
     pass
 
+ssl_certificate_description = "SSL/TLS certificate is used for establishing secure connections between servers. It ensures that the communication is encrypted and verifies the identity of the server. Yet they are not necessarily required for email delivery, as some servers may accept connections without a valid certificate. However, having a valid SSL/TLS certificate is considered a best practice for secure email communication."
 
 def retrieve_MX_records(domain: str, nameservers: Optional[List[str]] = None) -> List[Tuple[Optional[int], str]]:
     resolver = dns.resolver.Resolver()
@@ -145,15 +147,21 @@ def test_ssl_tls(
 
     except ssl.SSLCertVerificationError as e:
         result["connected"] = True
-        result["warning"] = f"Certificate error: {e.verify_message}"
+        verify_message = e.verify_message
+        if "unable to get local issuer certificate" in verify_message:
+            # this error needs to be more descriptive, as it doesn't tell the user what is wrong with the certificate
+            verify_message = "unable to get local issuer certificate, possibly due to missing intermediate certificates or untrusted root CA in the certificate chain"
+        result["warning"] = f"Certificate error: {verify_message}"
+        result["additional_info"] = ssl_certificate_description
+    except SSLCertificateError as e:
+        result["warning"] = str(e)
+        result["additional_info"] = ssl_certificate_description
     except ConnectionRefusedError:
         if not parked:
             # ECONNREFUSED is OK for parked domains
             result["error"] = "Connection refused"
     except SSLInternalError as e:
         result["error"] = str(e)
-    except SSLCertificateError as e:
-        result["warning"] = str(e)
     except TimeoutError:
         result["error"] = "Connection timed out"
     except Exception as e:
@@ -195,7 +203,7 @@ def validate_ssl(
             parked=parked,
         )
         return SSLMXScanResult(
-            preference=preference, mx=mx, port=result_mx["port"], error=result_mx["error"], warning=result_mx["warning"]
+            preference=preference, mx=mx, port=result_mx["port"], error=result_mx["error"], warning=result_mx["warning"], additional_info=result_mx.get("additional_info")
         )
 
     results = []

--- a/scan/libmailgoose/ssl_check.py
+++ b/scan/libmailgoose/ssl_check.py
@@ -40,7 +40,13 @@ class SSLCertificateError(Exception):
     pass
 
 
-ssl_certificate_description = "SSL/TLS certificate is used for establishing secure connections between servers. It ensures that the communication is encrypted and verifies the identity of the server. Yet they are not necessarily required for email delivery, as some servers may accept connections without a valid certificate. However, having a valid SSL/TLS certificate is considered a best practice for secure email communication."
+ssl_certificate_description = (
+    "An SSL/TLS certificate encrypts communication between servers while verifying the server's identity. "
+    "A website loading successfully in a browser does not guarantee that the mail server certificate is valid,  "
+    "as web and mail services typically use separate certificates that are configured independently. "
+    "Although a valid SSL/TLS certificate is not necessarily required for email delivery, "
+    "it is considered a best practice for ensuring secure email communication."
+)
 
 
 def retrieve_MX_records(domain: str, nameservers: Optional[List[str]] = None) -> List[Tuple[Optional[int], str]]:

--- a/scan/libmailgoose/ssl_check.py
+++ b/scan/libmailgoose/ssl_check.py
@@ -39,7 +39,9 @@ class SSLInternalError(Exception):
 class SSLCertificateError(Exception):
     pass
 
+
 ssl_certificate_description = "SSL/TLS certificate is used for establishing secure connections between servers. It ensures that the communication is encrypted and verifies the identity of the server. Yet they are not necessarily required for email delivery, as some servers may accept connections without a valid certificate. However, having a valid SSL/TLS certificate is considered a best practice for secure email communication."
+
 
 def retrieve_MX_records(domain: str, nameservers: Optional[List[str]] = None) -> List[Tuple[Optional[int], str]]:
     resolver = dns.resolver.Resolver()
@@ -203,7 +205,12 @@ def validate_ssl(
             parked=parked,
         )
         return SSLMXScanResult(
-            preference=preference, mx=mx, port=result_mx["port"], error=result_mx["error"], warning=result_mx["warning"], additional_info=result_mx.get("additional_info")
+            preference=preference,
+            mx=mx,
+            port=result_mx["port"],
+            error=result_mx["error"],
+            warning=result_mx["warning"],
+            additional_info=result_mx.get("additional_info"),
         )
 
     results = []

--- a/scan/libmailgoose/translate.py
+++ b/scan/libmailgoose/translate.py
@@ -1495,8 +1495,16 @@ TRANSLATIONS = {
             f"{PLACEHOLDER}: Mechanizm ptr wskazuje na {PLACEHOLDER}, ale ta domena/subdomena nie ma rekordów A/AAAA.",
         ),
         (
-            "SSL/TLS certificate is used for establishing secure connections between servers. It ensures that the communication is encrypted and verifies the identity of the server. Yet they are not necessarily required for email delivery, as some servers may accept connections without a valid certificate. However, having a valid SSL/TLS certificate is considered a best practice for secure email communication.",
-            "Certyfikat SSL/TLS jest używany do nawiązywania bezpiecznych połączeń między serwerami. Zapewnia szyfrowanie komunikacji i weryfikuje tożsamość serwera. Nie jest jednak konieczny do dostarczania wiadomości e-mail, ponieważ niektóre serwery mogą akceptować połączenia bez poprawnego certyfikatu. Niemniej posiadanie prawidłowego certyfikatu SSL/TLS jest uważane za najlepszą praktykę w zakresie bezpiecznej komunikacji e-mailowej.",
+            "An SSL/TLS certificate encrypts communication between servers while verifying the server's identity. "
+            "A website loading successfully in a browser does not guarantee that the mail server certificate is valid,  "
+            "as web and mail services typically use separate certificates that are configured independently. "
+            "Although a valid SSL/TLS certificate is not necessarily required for email delivery, "
+            "it is considered a best practice for ensuring secure email communication.",
+            "Certyfikat SSL/TLS zabezpiecza i szyfruje komunikację między serwerami, jednocześnie weryfikując tożsamość serwera. "
+            "Pomyślne załadowanie strony internetowej w przeglądarce nie gwarantuje, że certyfikat serwera pocztowego jest ważny, "
+            "ponieważ usługi internetowe i pocztowe zazwyczaj korzystają z oddzielnych certyfikatów, które są konfigurowane niezależnie. "
+            "Chociaż prawidłowy certyfikat SSL/TLS nie zawsze jest wymagany do dostarczania wiadomości e-mail, "
+            "uznaje się go za najlepszą praktykę zapewniającą bezpieczną komunikację e-mailową."
         ),
     ],
 }

--- a/scan/libmailgoose/translate.py
+++ b/scan/libmailgoose/translate.py
@@ -1350,8 +1350,8 @@ TRANSLATIONS = {
             "nie można zweryfikować, czy certyfikat jest zaufany",
         ),
         (
-            "Certificate error: unable to get local issuer certificate",
-            "Błąd certyfikatu: nie można zweryfikować, czy certyfikat jest zaufany",
+            "Certificate error: unable to get local issuer certificate, possibly due to missing intermediate certificates or untrusted root CA in the certificate chain",
+            "Błąd certyfikatu: nie można zweryfikować, czy certyfikat jest zaufany, możliwe przyczyny: brakujące certyfikaty pośrednie lub niezaufany certyfikat CA w łańcuchu certyfikatów",
         ),
         (
             "Connection refused",
@@ -1494,6 +1494,10 @@ TRANSLATIONS = {
             f"{PLACEHOLDER}: A ptr mechanism points to {PLACEHOLDER}, but that domain/subdomain does not have any A/AAAA records.",
             f"{PLACEHOLDER}: Mechanizm ptr wskazuje na {PLACEHOLDER}, ale ta domena/subdomena nie ma rekordów A/AAAA.",
         ),
+        (
+            "SSL/TLS certificate is used for establishing secure connections between servers. It ensures that the communication is encrypted and verifies the identity of the server. Yet they are not necessarily required for email delivery, as some servers may accept connections without a valid certificate. However, having a valid SSL/TLS certificate is considered a best practice for secure email communication.",
+            "Certyfikat SSL/TLS jest używany do nawiązywania bezpiecznych połączeń między serwerami. Zapewnia szyfrowanie komunikacji i weryfikuje tożsamość serwera. Nie jest jednak konieczny do dostarczania wiadomości e-mail, ponieważ niektóre serwery mogą akceptować połączenia bez poprawnego certyfikatu. Niemniej posiadanie prawidłowego certyfikatu SSL/TLS jest uważane za najlepszą praktykę w zakresie bezpiecznej komunikacji e-mailowej.",
+        )
     ],
 }
 
@@ -1585,6 +1589,8 @@ def _translate_domain_result(
             result.error = translate(result.error, language, nonexistent_translation_handler)
         if result.warning:
             result.warning = translate(result.warning, language, nonexistent_translation_handler)
+        if result.additional_info:
+            result.additional_info = translate(result.additional_info, language, nonexistent_translation_handler)
 
     new_domain_result.warnings = [
         translate(warning, language, nonexistent_translation_handler) for warning in new_domain_result.warnings

--- a/scan/libmailgoose/translate.py
+++ b/scan/libmailgoose/translate.py
@@ -1497,7 +1497,7 @@ TRANSLATIONS = {
         (
             "SSL/TLS certificate is used for establishing secure connections between servers. It ensures that the communication is encrypted and verifies the identity of the server. Yet they are not necessarily required for email delivery, as some servers may accept connections without a valid certificate. However, having a valid SSL/TLS certificate is considered a best practice for secure email communication.",
             "Certyfikat SSL/TLS jest używany do nawiązywania bezpiecznych połączeń między serwerami. Zapewnia szyfrowanie komunikacji i weryfikuje tożsamość serwera. Nie jest jednak konieczny do dostarczania wiadomości e-mail, ponieważ niektóre serwery mogą akceptować połączenia bez poprawnego certyfikatu. Niemniej posiadanie prawidłowego certyfikatu SSL/TLS jest uważane za najlepszą praktykę w zakresie bezpiecznej komunikacji e-mailowej.",
-        )
+        ),
     ],
 }
 

--- a/scan/libmailgoose/translate.py
+++ b/scan/libmailgoose/translate.py
@@ -1504,7 +1504,7 @@ TRANSLATIONS = {
             "Pomyślne załadowanie strony internetowej w przeglądarce nie gwarantuje, że certyfikat serwera pocztowego jest ważny, "
             "ponieważ usługi internetowe i pocztowe zazwyczaj korzystają z oddzielnych certyfikatów, które są konfigurowane niezależnie. "
             "Chociaż prawidłowy certyfikat SSL/TLS nie zawsze jest wymagany do dostarczania wiadomości e-mail, "
-            "uznaje się go za najlepszą praktykę zapewniającą bezpieczną komunikację e-mailową."
+            "uznaje się go za najlepszą praktykę zapewniającą bezpieczną komunikację e-mailową.",
         ),
     ],
 }


### PR DESCRIPTION
Add explanation of SSL/TLS certificates when `SSLCertificateError` or `ssl.SSLCertVerificationError` occurs during `ssl_check` for given MX. This helps less technical users to understand certificate issues better