### PR TITLE
Add spacing between warnings in the results table

### DIFF
--- a/app/static/index.css
+++ b/app/static/index.css
@@ -51,6 +51,10 @@ td ul {
     padding-left: 10px;
 }
 
+td ul li + li {
+    margin-top: 10px;
+}
+
 .input-group.with-margin {
     margin: 10px 0;
 }

--- a/scan/libmailgoose/translate.py
+++ b/scan/libmailgoose/translate.py
@@ -540,6 +540,11 @@ TRANSLATIONS = {
             "obciążenia serwerów DNS.",
         ),
         (
+            f"Error when processing {PLACEHOLDER}: The ptr mechanism should not be used - (RFC 7208 § 5.5)",
+            f"Błąd przy analizie {PLACEHOLDER}: Zgodnie ze specyfikacją SPF, nie należy używać mechanizmu 'ptr'. Pod adresem "
+            "https://tools.ietf.org/html/rfc7208#section-5.5 można znaleźć uzasadnienie tej rekomendacji.",
+        ),
+        (
             f"{PLACEHOLDER}: The ptr mechanism should not be used - (RFC 7208 § 5.5)",
             f"{PLACEHOLDER}: Zgodnie ze specyfikacją SPF, nie należy używać mechanizmu 'ptr'. Pod adresem "
             "https://tools.ietf.org/html/rfc7208#section-5.5 można znaleźć uzasadnienie tej rekomendacji.",


### PR DESCRIPTION
Fixes #199.

When a single mechanism has more than one warning or error, they're rendered as a list but with no gap between the items. With multiline entries this makes them run into each other and it's hard to tell where one ends and the next begins (as in the screenshot on the issue).

This adds a small top margin between consecutive list items so each warning is visually separated. Results with only one warning are unchanged.
