### PR TITLE
Warn when DNSSEC is not enabled for the domain

### DIFF
--- a/scan/libmailgoose/scan.py
+++ b/scan/libmailgoose/scan.py
@@ -303,8 +303,9 @@ def scan_domain(
         domain_result.domain_does_not_exist = True
         return domain_result
 
+    # DNSSEC is a property of the DNS zone, so we check it on the base domain rather than on a subdomain.
     try:
-        if not checkdmarc.dnssec.test_dnssec(from_domain, nameservers=nameservers, timeout=timeout):
+        if not checkdmarc.dnssec.test_dnssec(domain_result.base_domain, nameservers=nameservers, timeout=timeout):
             domain_result.warnings.append(
                 "DNSSEC is not enabled for the domain. It is not required for correct e-mail sender configuration, "
                 "but it provides additional protection against DNS spoofing, which could otherwise be used to "
@@ -313,7 +314,7 @@ def scan_domain(
     except Exception:
         # DNSSEC status is supplementary information - if we are unable to determine it, we skip the
         # warning rather than failing the whole scan.
-        LOGGER.exception("Unable to determine DNSSEC status for %s", from_domain)
+        LOGGER.exception("Unable to determine DNSSEC status for %s", domain_result.base_domain)
 
     try:
         spf_query = checkdmarc.spf.query_spf_record(envelope_domain, nameservers=nameservers, timeout=timeout)

--- a/scan/libmailgoose/scan.py
+++ b/scan/libmailgoose/scan.py
@@ -8,6 +8,7 @@ from email.message import Message as EmailMessage
 from typing import Any, Callable, Dict, List, Optional
 
 import checkdmarc.dmarc
+import checkdmarc.dnssec
 import checkdmarc.smtp
 import checkdmarc.utils
 import dkim
@@ -301,6 +302,18 @@ def scan_domain(
     if not any([check_domain_exists(domain) for domain in domains_to_check]):
         domain_result.domain_does_not_exist = True
         return domain_result
+
+    try:
+        if not checkdmarc.dnssec.test_dnssec(from_domain, nameservers=nameservers, timeout=timeout):
+            domain_result.warnings.append(
+                "DNSSEC is not enabled for the domain. It is not required for correct e-mail sender configuration, "
+                "but it provides additional protection against DNS spoofing, which could otherwise be used to "
+                "undermine SPF, DKIM and DMARC. Consider enabling it if your DNS provider supports it."
+            )
+    except Exception:
+        # DNSSEC status is supplementary information - if we are unable to determine it, we skip the
+        # warning rather than failing the whole scan.
+        LOGGER.exception("Unable to determine DNSSEC status for %s", from_domain)
 
     try:
         spf_query = checkdmarc.spf.query_spf_record(envelope_domain, nameservers=nameservers, timeout=timeout)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -37,7 +37,11 @@ class APITestCase(BaseTestCase):
                         "spf_not_required_because_of_correct_dmarc": False,
                         "domain": "starts-with-whitespace.dmarc.test.mailgoose.cert.pl",
                         "base_domain": "cert.pl",
-                        "warnings": [],
+                        "warnings": [
+                            "DNSSEC is not enabled for the domain. It is not required for correct e-mail sender configuration, "
+                            "but it provides additional protection against DNS spoofing, which could otherwise be used to "
+                            "undermine SPF, DKIM and DMARC. Consider enabling it if your DNS provider supports it."
+                        ],
                         "ssl": {
                             "results": [
                                 {


### PR DESCRIPTION
Draft for #80. Opening early to get your input on a couple of points before I finish it.

### What this does

Adds a DNSSEC check to `scan_domain()`. It reuses `checkdmarc.dnssec.test_dnssec()` (checkdmarc is already a dependency, so nothing new is added), and when the domain isn't signed it adds an advisory warning to the domain-level warnings. The check is wrapped so that if DNSSEC status can't be determined the scan still completes normally.

### Open questions

**1. Advisory vs. scored.** I went with the advisory option from my comment on #80: DNSSEC is reported as a warning but does not change `num_checked_mechanisms`, so existing SPF/DMARC/DKIM scores are unaffected. If you'd rather it be a full scored mechanism with its own card, I'm happy to switch.

**2. How you'd like it tested.** `test_dnssec` only returns the right answer when the query goes through a resolver that actually does DNSSEC validation. I verified the function against a validating resolver and it's accurate: cloudflare.com, ietf.org and example.com come back as signed, github.com and microsoft.com as unsigned. In production the call uses the configured nameservers (your bind9 with `dnssec-validation auto`), the same way the SPF and DMARC queries already pass `nameservers`.

The existing checks mostly test against fixtures under `test.mailgoose.cert.pl`, which I can't add records to. Would you prefer to add a signed and an unsigned fixture there for me to assert against, or is a test against a known external domain acceptable here? I'll add the test once you let me know.

**3. Translations.** Left out for now since the wording may change depending on the above. Once it's settled I'll add the pl_PL and lt_LT entries to `translate.py` (happy to draft the Polish, though you'll likely want to adjust it).
