### PR TITLE
Fix implicit TLS EHLO check to handle fragmented replies

### DIFF
--- a/scan/libmailgoose/ssl_check.py
+++ b/scan/libmailgoose/ssl_check.py
@@ -5,6 +5,7 @@ import ipaddress
 import smtplib
 import socket
 import ssl
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -140,11 +141,22 @@ def test_ssl_tls(
                     result["tls"] = True
                     validate_tls_info(tls_sock)
                     tls_sock.send(b"EHLO %s\r\n" % "mailgoose".encode())
-                    welcome_banner = tls_sock.recv(1024).decode()
-                    if "220" not in welcome_banner:
+                    # The greeting banner and the EHLO reply are often delivered in a single
+                    # TCP segment, so a single recv() may capture only the "220" banner while
+                    # the "250" EHLO reply is already buffered on the socket. Issuing a second
+                    # blocking recv() would then hang until the timeout and falsely report a
+                    # failed EHLO. Read in a loop until we have the "250" reply (or timeout).
+                    response = b""
+                    deadline = time.monotonic() + timeout
+                    while b"250" not in response and time.monotonic() < deadline:
+                        chunk = tls_sock.recv(1024)
+                        if not chunk:
+                            break
+                        response += chunk
+                    response_text = response.decode(errors="replace")
+                    if "220" not in response_text:
                         raise SSLInternalError("No welcome banner received on implicit TLS connection")
-                    ehlo_response = tls_sock.recv(1024).decode()
-                    if "250" not in ehlo_response:
+                    if "250" not in response_text:
                         raise SSLInternalError("No EHLO response received on implicit TLS connection")
 
                     tls_sock.send(b"STARTTLS\r\n")


### PR DESCRIPTION
## What's the bug?

In `test_ssl_tls()` for **implicit TLS** connections (`SSLEnum.IMPLICIT`), the code sends EHLO and then performs two separate blocking `recv()` calls:

```python
tls_sock.send(b"EHLO %s\r\n" % "mailgoose".encode())
welcome_banner = tls_sock.recv(1024).decode()
if "220" not in welcome_banner:
    raise SSLInternalError(...)
ehlo_response = tls_sock.recv(1024).decode()
if "250" not in ehlo_response:
    raise SSLInternalError("No EHLO response received on implicit TLS connection")
```

An SMTP/ESMTP server commonly returns its greeting banner **and** the reply to EHLO in a single TCP segment. In that case the first `recv()` consumes both, the second `recv()` blocks until the socket timeout and returns empty (or a partial read), and the scan falsely reports `No EHLO response received` — marking a perfectly healthy implicit-TLS port as broken.

## The fix

Replace the two blocking reads with a single read loop that accumulates bytes until the `250` reply is captured or the connection times out (using the same `timeout` already passed in), then validates both the `220` banner and the `250` EHLO response:

```python
tls_sock.send(b"EHLO %s\r\n" % "mailgoose".encode())
response = b""
deadline = time.monotonic() + timeout
while b"250" not in response and time.monotonic() < deadline:
    chunk = tls_sock.recv(1024)
    if not chunk:
        break
    response += chunk
response_text = response.decode(errors="replace")
if "220" not in response_text:
    raise SSLInternalError("No welcome banner received on implicit TLS connection")
if "250" not in response_text:
    raise SSLInternalError("No EHLO response received on implicit TLS connection")
```

The STARTTLS branch already handles this correctly via `smtplib` (which reads the full response); only the implicit-TLS branch was affected. This is a robustness fix for real-world SMTP servers that coalesce the banner and EHLO reply into one segment.